### PR TITLE
Add core data models with migrations, factories, and tests

### DIFF
--- a/app/Enums/AutomationStepKind.php
+++ b/app/Enums/AutomationStepKind.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum AutomationStepKind: string
+{
+    case Delay = 'delay';
+    case SendEmail = 'send_email';
+    case Branch = 'branch';
+    case Exit = 'exit';
+}

--- a/app/Enums/ContactStatus.php
+++ b/app/Enums/ContactStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ContactStatus: string
+{
+    case Active = 'active';
+    case Unsubscribed = 'unsubscribed';
+    case Bounced = 'bounced';
+    case Complained = 'complained';
+}

--- a/app/Enums/DeliveryStatus.php
+++ b/app/Enums/DeliveryStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum DeliveryStatus: string
+{
+    case Pending = 'pending';
+    case Sending = 'sending';
+    case Sent = 'sent';
+    case Bounced = 'bounced';
+    case Complained = 'complained';
+    case Failed = 'failed';
+}

--- a/app/Enums/SuppressionReason.php
+++ b/app/Enums/SuppressionReason.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum SuppressionReason: string
+{
+    case Bounce = 'bounce';
+    case Complaint = 'complaint';
+    case Manual = 'manual';
+}

--- a/app/Models/Automation.php
+++ b/app/Models/Automation.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Automation extends Model
+{
+    /** @use HasFactory<\Database\Factories\AutomationFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'conditions' => 'array',
+        'is_active' => 'boolean',
+    ];
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function steps(): HasMany
+    {
+        return $this->hasMany(AutomationStep::class);
+    }
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(Delivery::class);
+    }
+}

--- a/app/Models/AutomationStep.php
+++ b/app/Models/AutomationStep.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AutomationStepKind;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AutomationStep extends Model
+{
+    /** @use HasFactory<\Database\Factories\AutomationStepFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'config' => 'array',
+        'kind' => AutomationStepKind::class,
+    ];
+
+    public function automation(): BelongsTo
+    {
+        return $this->belongsTo(Automation::class);
+    }
+}

--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ContactStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Contact extends Model
+{
+    /** @use HasFactory<\Database\Factories\ContactFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'attributes' => 'array',
+        'status' => ContactStatus::class,
+    ];
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function lists(): BelongsToMany
+    {
+        return $this->belongsToMany(ContactList::class, 'list_contact')
+            ->withPivot(['subscribed_at', 'unsubscribed_at', 'meta']);
+    }
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(Delivery::class);
+    }
+
+    public function events(): HasMany
+    {
+        return $this->hasMany(Event::class);
+    }
+}

--- a/app/Models/ContactList.php
+++ b/app/Models/ContactList.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class ContactList extends Model
+{
+    /** @use HasFactory<\Database\Factories\ContactListFactory> */
+    use HasFactory;
+
+    protected $table = 'lists';
+
+    protected $guarded = [];
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function contacts(): BelongsToMany
+    {
+        return $this->belongsToMany(Contact::class, 'list_contact')
+            ->withPivot(['subscribed_at', 'unsubscribed_at', 'meta']);
+    }
+}

--- a/app/Models/Delivery.php
+++ b/app/Models/Delivery.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\DeliveryStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Delivery extends Model
+{
+    /** @use HasFactory<\Database\Factories\DeliveryFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'scheduled_at' => 'datetime',
+        'sent_at' => 'datetime',
+        'status' => DeliveryStatus::class,
+    ];
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function contact(): BelongsTo
+    {
+        return $this->belongsTo(Contact::class);
+    }
+
+    public function template(): BelongsTo
+    {
+        return $this->belongsTo(Template::class);
+    }
+
+    public function automation(): BelongsTo
+    {
+        return $this->belongsTo(Automation::class);
+    }
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Event extends Model
+{
+    /** @use HasFactory<\Database\Factories\EventFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'payload' => 'array',
+        'occurred_at' => 'datetime',
+    ];
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function contact(): BelongsTo
+    {
+        return $this->belongsTo(Contact::class);
+    }
+}

--- a/app/Models/SmtpSetting.php
+++ b/app/Models/SmtpSetting.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SmtpSetting extends Model
+{
+    /** @use HasFactory<\Database\Factories\SmtpSettingFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'meta' => 'array',
+        'is_active' => 'boolean',
+    ];
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+}

--- a/app/Models/Suppression.php
+++ b/app/Models/Suppression.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\SuppressionReason;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Suppression extends Model
+{
+    /** @use HasFactory<\Database\Factories\SuppressionFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'reason' => SuppressionReason::class,
+        'source' => 'array',
+    ];
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+}

--- a/app/Models/Template.php
+++ b/app/Models/Template.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Template extends Model
+{
+    /** @use HasFactory<\Database\Factories\TemplateFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'editor_meta' => 'array',
+    ];
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(Delivery::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -18,6 +19,7 @@ class User extends Authenticatable
      * @var list<string>
      */
     protected $fillable = [
+        'workspace_id',
         'name',
         'email',
         'password',
@@ -44,5 +46,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
     }
 }

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Workspace extends Model
+{
+    /** @use HasFactory<\Database\Factories\WorkspaceFactory> */
+    use HasFactory;
+
+    protected $guarded = [];
+
+    public function contacts(): HasMany
+    {
+        return $this->hasMany(Contact::class);
+    }
+
+    public function templates(): HasMany
+    {
+        return $this->hasMany(Template::class);
+    }
+
+    public function automations(): HasMany
+    {
+        return $this->hasMany(Automation::class);
+    }
+
+    public function smtpSettings(): HasMany
+    {
+        return $this->hasMany(SmtpSetting::class);
+    }
+
+    public function lists(): HasMany
+    {
+        return $this->hasMany(ContactList::class);
+    }
+
+    public function events(): HasMany
+    {
+        return $this->hasMany(Event::class);
+    }
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(Delivery::class);
+    }
+
+    public function suppressions(): HasMany
+    {
+        return $this->hasMany(Suppression::class);
+    }
+
+    public function users(): HasMany
+    {
+        return $this->hasMany(User::class);
+    }
+}

--- a/database/factories/AutomationFactory.php
+++ b/database/factories/AutomationFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Automation>
+ */
+class AutomationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'name' => fake()->sentence(2),
+            'trigger_event' => fake()->word(),
+            'conditions' => [],
+            'is_active' => false,
+            'timezone' => 'UTC',
+        ];
+    }
+}

--- a/database/factories/AutomationStepFactory.php
+++ b/database/factories/AutomationStepFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\AutomationStepKind;
+use App\Models\Automation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<\App\Models\AutomationStep>
+ */
+class AutomationStepFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'automation_id' => Automation::factory(),
+            'uid' => Str::uuid()->toString(),
+            'kind' => AutomationStepKind::Delay,
+            'config' => [],
+            'next_step_uid' => null,
+            'alt_next_step_uid' => null,
+        ];
+    }
+}

--- a/database/factories/ContactFactory.php
+++ b/database/factories/ContactFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ContactStatus;
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Contact>
+ */
+class ContactFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'email' => fake()->unique()->safeEmail(),
+            'first_name' => fake()->firstName(),
+            'last_name' => fake()->lastName(),
+            'attributes' => [],
+            'status' => ContactStatus::Active,
+        ];
+    }
+}

--- a/database/factories/ContactListFactory.php
+++ b/database/factories/ContactListFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\ContactList>
+ */
+class ContactListFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'name' => fake()->words(2, true),
+        ];
+    }
+}

--- a/database/factories/DeliveryFactory.php
+++ b/database/factories/DeliveryFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\DeliveryStatus;
+use App\Models\Automation;
+use App\Models\Contact;
+use App\Models\Template;
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<\App\Models\Delivery>
+ */
+class DeliveryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'contact_id' => Contact::factory(),
+            'template_id' => Template::factory(),
+            'automation_id' => Automation::factory(),
+            'step_uid' => Str::uuid()->toString(),
+            'status' => DeliveryStatus::Pending,
+            'provider_message_id' => Str::uuid()->toString(),
+            'scheduled_at' => now(),
+            'sent_at' => null,
+            'error' => null,
+        ];
+    }
+}

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Contact;
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Event>
+ */
+class EventFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'name' => fake()->word(),
+            'contact_id' => Contact::factory(),
+            'payload' => [],
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/factories/SmtpSettingFactory.php
+++ b/database/factories/SmtpSettingFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\SmtpSetting>
+ */
+class SmtpSettingFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'host' => fake()->domainName(),
+            'port' => 587,
+            'username' => fake()->userName(),
+            'password_encrypted' => fake()->password(),
+            'encryption' => 'tls',
+            'from_name' => fake()->name(),
+            'from_email' => fake()->safeEmail(),
+            'reply_to' => fake()->safeEmail(),
+            'meta' => [],
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/factories/SuppressionFactory.php
+++ b/database/factories/SuppressionFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SuppressionReason;
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Suppression>
+ */
+class SuppressionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'email' => fake()->safeEmail(),
+            'reason' => SuppressionReason::Manual,
+            'source' => [],
+        ];
+    }
+}

--- a/database/factories/TemplateFactory.php
+++ b/database/factories/TemplateFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Workspace;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Template>
+ */
+class TemplateFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'workspace_id' => Workspace::factory(),
+            'name' => fake()->sentence(3),
+            'subject' => fake()->sentence(),
+            'html' => '<p>'.fake()->paragraph().'</p>',
+            'text' => fake()->paragraph(),
+            'editor_meta' => [],
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,12 +2,13 @@
 
 namespace Database\Factories;
 
+use App\Models\Workspace;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<\App\Models\User>
  */
 class UserFactory extends Factory
 {
@@ -24,6 +25,7 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
+            'workspace_id' => Workspace::factory(),
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),

--- a/database/factories/WorkspaceFactory.php
+++ b/database/factories/WorkspaceFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Workspace>
+ */
+class WorkspaceFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->company(),
+            'slug' => fake()->unique()->slug(),
+        ];
+    }
+}

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();

--- a/database/migrations/2025_09_06_095950_create_contacts_table.php
+++ b/database/migrations/2025_09_06_095950_create_contacts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Enums\ContactStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('contacts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->string('email');
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->jsonb('attributes')->nullable();
+            $table->string('status')->default(ContactStatus::Active->value);
+            $table->timestamps();
+            $table->unique(['workspace_id', 'email']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('contacts');
+    }
+};

--- a/database/migrations/2025_09_06_095950_create_smtp_settings_table.php
+++ b/database/migrations/2025_09_06_095950_create_smtp_settings_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('smtp_settings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->string('host');
+            $table->unsignedSmallInteger('port');
+            $table->string('username');
+            $table->string('password_encrypted');
+            $table->string('encryption')->nullable();
+            $table->string('from_name')->nullable();
+            $table->string('from_email');
+            $table->string('reply_to')->nullable();
+            $table->jsonb('meta')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('smtp_settings');
+    }
+};

--- a/database/migrations/2025_09_06_095950_create_workspaces_table.php
+++ b/database/migrations/2025_09_06_095950_create_workspaces_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('workspaces', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('workspaces');
+    }
+};

--- a/database/migrations/2025_09_06_095951_create_lists_table.php
+++ b/database/migrations/2025_09_06_095951_create_lists_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('lists', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('lists');
+    }
+};

--- a/database/migrations/2025_09_06_095951_create_templates_table.php
+++ b/database/migrations/2025_09_06_095951_create_templates_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('templates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('subject');
+            $table->longText('html');
+            $table->text('text')->nullable();
+            $table->jsonb('editor_meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('templates');
+    }
+};

--- a/database/migrations/2025_09_06_095952_create_automation_steps_table.php
+++ b/database/migrations/2025_09_06_095952_create_automation_steps_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('automation_steps', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('automation_id')->constrained()->cascadeOnDelete();
+            $table->string('uid');
+            $table->string('kind');
+            $table->jsonb('config')->nullable();
+            $table->string('next_step_uid')->nullable();
+            $table->string('alt_next_step_uid')->nullable();
+            $table->timestamps();
+            $table->unique(['automation_id', 'uid']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('automation_steps');
+    }
+};

--- a/database/migrations/2025_09_06_095952_create_automations_table.php
+++ b/database/migrations/2025_09_06_095952_create_automations_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('automations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('trigger_event');
+            $table->jsonb('conditions')->nullable();
+            $table->boolean('is_active')->default(false);
+            $table->string('timezone');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('automations');
+    }
+};

--- a/database/migrations/2025_09_06_095952_create_events_table.php
+++ b/database/migrations/2025_09_06_095952_create_events_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('events', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->foreignId('contact_id')->nullable()->constrained()->nullOnDelete();
+            $table->jsonb('payload')->nullable();
+            $table->timestamp('occurred_at');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('events');
+    }
+};

--- a/database/migrations/2025_09_06_095953_create_deliveries_table.php
+++ b/database/migrations/2025_09_06_095953_create_deliveries_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Enums\DeliveryStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('contact_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('template_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('automation_id')->constrained()->cascadeOnDelete();
+            $table->string('step_uid');
+            $table->string('status')->default(DeliveryStatus::Pending->value);
+            $table->string('provider_message_id')->nullable();
+            $table->timestamp('scheduled_at');
+            $table->timestamp('sent_at')->nullable();
+            $table->text('error')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('deliveries');
+    }
+};

--- a/database/migrations/2025_09_06_095953_create_list_contact_table.php
+++ b/database/migrations/2025_09_06_095953_create_list_contact_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('list_contact', function (Blueprint $table) {
+            $table->foreignId('list_id')->constrained('lists')->cascadeOnDelete();
+            $table->foreignId('contact_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('subscribed_at')->nullable();
+            $table->timestamp('unsubscribed_at')->nullable();
+            $table->jsonb('meta')->nullable();
+            $table->primary(['list_id', 'contact_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('list_contact');
+    }
+};

--- a/database/migrations/2025_09_06_095953_create_suppressions_table.php
+++ b/database/migrations/2025_09_06_095953_create_suppressions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('suppressions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->string('email');
+            $table->string('reason');
+            $table->jsonb('source')->nullable();
+            $table->timestamps();
+            $table->unique(['workspace_id', 'email']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('suppressions');
+    }
+};

--- a/tests/Unit/Models/RelationsTest.php
+++ b/tests/Unit/Models/RelationsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Models\Automation;
+use App\Models\AutomationStep;
+use App\Models\Contact;
+use App\Models\Delivery;
+use App\Models\Template;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+it('workspace has many contacts', function () {
+    $workspace = Workspace::factory()->has(Contact::factory()->count(2))->create();
+
+    expect($workspace->contacts)->toHaveCount(2);
+});
+
+it('contact belongs to workspace', function () {
+    $workspace = Workspace::factory()->create();
+    $contact = Contact::factory()->for($workspace)->create();
+
+    expect($contact->workspace->is($workspace))->toBeTrue();
+});
+
+it('delivery belongs to contact template automation', function () {
+    $workspace = Workspace::factory()->create();
+    $contact = Contact::factory()->for($workspace)->create();
+    $template = Template::factory()->for($workspace)->create();
+    $automation = Automation::factory()->for($workspace)->create();
+
+    $delivery = Delivery::factory()
+        ->for($workspace)
+        ->for($contact)
+        ->for($template)
+        ->for($automation)
+        ->create();
+
+    expect($delivery->contact->is($contact))->toBeTrue()
+        ->and($delivery->template->is($template))->toBeTrue()
+        ->and($delivery->automation->is($automation))->toBeTrue();
+});
+
+it('automation steps have unique uid', function () {
+    $automation = Automation::factory()->create();
+    $uid = 'step-uid';
+
+    AutomationStep::factory()->for($automation)->create(['uid' => $uid]);
+
+    expect(fn () => AutomationStep::factory()->for($automation)->create(['uid' => $uid]))
+        ->toThrow(\Illuminate\Database\QueryException::class);
+});


### PR DESCRIPTION
## Summary
- define migrations for workspaces, contacts, templates, automations, deliveries, and more
- implement Eloquent models and factories with enum casts and relationships
- add unit tests covering model associations and unique step UIDs

## Testing
- `php artisan migrate --database=sqlite --force`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68bc05cc4ccc832b8c68dec4db4d5024