### PR TITLE
Implement Sanctum authentication with workspace scoping

### DIFF
--- a/app/Http/Controllers/AuthTokenController.php
+++ b/app/Http/Controllers/AuthTokenController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthTokenController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        $workspace = currentWorkspace();
+
+        $user = User::where('workspace_id', $workspace->id)
+            ->where('email', $credentials['email'])
+            ->first();
+
+        if ($user === null || ! Hash::check($credentials['password'], $user->password)) {
+            return response()->json([
+                'errors' => [
+                    ['status' => '401', 'title' => 'Invalid credentials'],
+                ],
+            ], 401);
+        }
+
+        $token = $user->createToken('api')->plainTextToken;
+
+        return response()->json([
+            'data' => [
+                'token' => $token,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Middleware/WorkspaceResolve.php
+++ b/app/Http/Middleware/WorkspaceResolve.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\Workspace;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class WorkspaceResolve
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $slug = $request->header('X-Workspace');
+
+        if ($slug === null) {
+            return response()->json([
+                'errors' => [
+                    ['status' => '400', 'title' => 'Workspace header missing'],
+                ],
+            ], 400);
+        }
+
+        $workspace = Workspace::where('slug', $slug)->first();
+
+        if ($workspace === null) {
+            return response()->json([
+                'errors' => [
+                    ['status' => '404', 'title' => 'Workspace not found'],
+                ],
+            ], 404);
+        }
+
+        app()->instance('currentWorkspace', $workspace);
+
+        return $next($request);
+    }
+}

--- a/app/Models/Automation.php
+++ b/app/Models/Automation.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ScopedToWorkspace;
+
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Automation extends Model
 {
     /** @use HasFactory<\Database\Factories\AutomationFactory> */
-    use HasFactory;
+    use HasFactory, ScopedToWorkspace;
 
     protected $guarded = [];
 

--- a/app/Models/Concerns/ScopedToWorkspace.php
+++ b/app/Models/Concerns/ScopedToWorkspace.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+trait ScopedToWorkspace
+{
+    protected static function bootScopedToWorkspace(): void
+    {
+        static::addGlobalScope('workspace', function (Builder $builder): void {
+            if (function_exists('currentWorkspace') && null !== currentWorkspace()) {
+                $builder->where($builder->getModel()->getTable().'.workspace_id', currentWorkspace()->id);
+            }
+        });
+
+        static::creating(function (Model $model): void {
+            if (function_exists('currentWorkspace') && null !== currentWorkspace()) {
+                $model->workspace_id ??= currentWorkspace()->id;
+            }
+        });
+    }
+}

--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ScopedToWorkspace;
+
 use App\Enums\ContactStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -12,7 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Contact extends Model
 {
     /** @use HasFactory<\Database\Factories\ContactFactory> */
-    use HasFactory;
+    use HasFactory, ScopedToWorkspace;
 
     protected $guarded = [];
 

--- a/app/Models/ContactList.php
+++ b/app/Models/ContactList.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ScopedToWorkspace;
+
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 class ContactList extends Model
 {
     /** @use HasFactory<\Database\Factories\ContactListFactory> */
-    use HasFactory;
+    use HasFactory, ScopedToWorkspace;
 
     protected $table = 'lists';
 

--- a/app/Models/Delivery.php
+++ b/app/Models/Delivery.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ScopedToWorkspace;
+
 use App\Enums\DeliveryStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -10,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class Delivery extends Model
 {
     /** @use HasFactory<\Database\Factories\DeliveryFactory> */
-    use HasFactory;
+    use HasFactory, ScopedToWorkspace;
 
     protected $guarded = [];
 

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ScopedToWorkspace;
+
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class Event extends Model
 {
     /** @use HasFactory<\Database\Factories\EventFactory> */
-    use HasFactory;
+    use HasFactory, ScopedToWorkspace;
 
     protected $guarded = [];
 

--- a/app/Models/SmtpSetting.php
+++ b/app/Models/SmtpSetting.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ScopedToWorkspace;
+
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class SmtpSetting extends Model
 {
     /** @use HasFactory<\Database\Factories\SmtpSettingFactory> */
-    use HasFactory;
+    use HasFactory, ScopedToWorkspace;
 
     protected $guarded = [];
 

--- a/app/Models/Suppression.php
+++ b/app/Models/Suppression.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ScopedToWorkspace;
+
 use App\Enums\SuppressionReason;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -10,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class Suppression extends Model
 {
     /** @use HasFactory<\Database\Factories\SuppressionFactory> */
-    use HasFactory;
+    use HasFactory, ScopedToWorkspace;
 
     protected $guarded = [];
 

--- a/app/Models/Template.php
+++ b/app/Models/Template.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\ScopedToWorkspace;
+
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Template extends Model
 {
     /** @use HasFactory<\Database\Factories\TemplateFactory> */
-    use HasFactory;
+    use HasFactory, ScopedToWorkspace;
 
     protected $guarded = [];
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,17 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Models\Concerns\ScopedToWorkspace;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, ScopedToWorkspace;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Gate::before(function ($user) {
+            $workspace = currentWorkspace();
+
+            if ($workspace !== null && $user->workspace_id !== $workspace->id) {
+                return false;
+            }
+
+            return null;
+        });
     }
 }

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Workspace;
+
+function currentWorkspace(): ?Workspace
+{
+    return app()->bound('currentWorkspace') ? app()->get('currentWorkspace') : null;
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
+use App\Http\Middleware\WorkspaceResolve;
+use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -7,11 +11,15 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'auth' => Authenticate::class,
+            'workspace' => WorkspaceResolve::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/Support/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'sanctum' => [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+        ],
     ],
 
     /*

--- a/database/migrations/0001_01_01_000003_create_personal_access_tokens_table.php
+++ b/database/migrations/0001_01_01_000003_create_personal_access_tokens_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table): void {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\AuthTokenController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/auth/token', AuthTokenController::class)->middleware('workspace');
+
+Route::middleware(['auth:sanctum', 'workspace'])->get('/ping', function () {
+    return response()->json(['data' => ['pong' => true]]);
+});

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+it('can request token with email/password', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create([
+        'password' => bcrypt('secret'),
+    ]);
+
+    $response = postJson('/api/auth/token', [
+        'email' => $user->email,
+        'password' => 'secret',
+    ], ['X-Workspace' => $workspace->slug]);
+
+    $response->assertOk()
+        ->assertJsonStructure(['data' => ['token']]);
+});

--- a/tests/Feature/WorkspaceScopeTest.php
+++ b/tests/Feature/WorkspaceScopeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use function Pest\Laravel\getJson;
+
+uses(RefreshDatabase::class);
+
+it('requires token and workspace header', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+    $token = $user->createToken('api')->plainTextToken;
+
+    getJson('/api/ping')->assertUnauthorized();
+
+    getJson('/api/ping', ['Authorization' => 'Bearer '.$token])
+        ->assertStatus(400);
+
+    $this->flushHeaders();
+    auth()->forgetGuards();
+
+    getJson('/api/ping', ['X-Workspace' => $workspace->slug])
+        ->assertUnauthorized();
+
+    getJson('/api/ping', [
+        'Authorization' => 'Bearer '.$token,
+        'X-Workspace' => $workspace->slug,
+    ])->assertOk();
+});


### PR DESCRIPTION
## Summary
- add Sanctum token issuance endpoint
- resolve current workspace via `X-Workspace` header
- scope models and gates to current workspace

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc0971fd38832b9d84e6d5e2eb6aaa