### PR TITLE
Add per-workspace SMTP settings management

### DIFF
--- a/app/Filament/Resources/SmtpSettingResource.php
+++ b/app/Filament/Resources/SmtpSettingResource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\SmtpSettingResource\Pages\EditSmtpSetting;
+use App\Models\SmtpSetting;
+use Filament\Forms;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+
+class SmtpSettingResource extends Resource
+{
+    protected static ?string $model = SmtpSetting::class;
+
+    protected static ?string $navigationGroup = 'Settings';
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\TextInput::make('host')->required(),
+            Forms\Components\TextInput::make('port')->numeric()->required(),
+            Forms\Components\TextInput::make('username')->required(),
+            Forms\Components\TextInput::make('password')
+                ->password()
+                ->afterStateHydrated(fn (Forms\Components\TextInput $component) => $component->state('')),
+            Forms\Components\TextInput::make('encryption'),
+            Forms\Components\TextInput::make('from_name'),
+            Forms\Components\TextInput::make('from_email')->email()->required(),
+            Forms\Components\TextInput::make('reply_to')->email(),
+            Forms\Components\Toggle::make('is_active'),
+        ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'edit' => EditSmtpSetting::route('/smtp-settings'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SmtpSettingResource/Pages/EditSmtpSetting.php
+++ b/app/Filament/Resources/SmtpSettingResource/Pages/EditSmtpSetting.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\SmtpSettingResource\Pages;
+
+use App\Filament\Resources\SmtpSettingResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditSmtpSetting extends EditRecord
+{
+    protected static string $resource = SmtpSettingResource::class;
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        if (isset($data['password']) && $data['password'] !== '') {
+            $data['password_encrypted'] = encrypt($data['password']);
+        }
+
+        unset($data['password']);
+
+        return $data;
+    }
+}

--- a/app/Http/Controllers/SmtpSettingsController.php
+++ b/app/Http/Controllers/SmtpSettingsController.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Mail\TestSmtpMail;
+use App\Models\SmtpSetting;
+use App\Services\Mail\MailerResolver;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SmtpSettingsController extends Controller
+{
+    public function store(Request $request): Response
+    {
+        $data = $request->validate([
+            'host' => ['required', 'string'],
+            'port' => ['required', 'integer'],
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+            'encryption' => ['nullable', 'string'],
+            'from_name' => ['nullable', 'string'],
+            'from_email' => ['required', 'email'],
+            'reply_to' => ['nullable', 'email'],
+        ]);
+
+        $setting = SmtpSetting::updateOrCreate(
+            ['workspace_id' => currentWorkspace()->id],
+            [
+                'host' => $data['host'],
+                'port' => $data['port'],
+                'username' => $data['username'],
+                'password_encrypted' => encrypt($data['password']),
+                'encryption' => $data['encryption'] ?? null,
+                'from_name' => $data['from_name'] ?? null,
+                'from_email' => $data['from_email'],
+                'reply_to' => $data['reply_to'] ?? null,
+                'is_active' => true,
+            ]
+        );
+
+        return response()->json(['data' => $this->transform($setting)]);
+    }
+
+    public function show(): Response
+    {
+        $setting = SmtpSetting::where('workspace_id', currentWorkspace()->id)->first();
+
+        if ($setting === null) {
+            return response()->json([
+                'errors' => [
+                    ['status' => '404', 'title' => 'SMTP setting not found'],
+                ],
+            ], 404);
+        }
+
+        return response()->json(['data' => $this->transform($setting)]);
+    }
+
+    public function test(Request $request, MailerResolver $resolver): Response
+    {
+        $data = $request->validate([
+            'to' => ['required', 'email'],
+        ]);
+
+        $mailer = $resolver->for(currentWorkspace());
+        $mailer->to($data['to'])->send(new TestSmtpMail);
+
+        return response()->json(['data' => ['sent' => true]]);
+    }
+
+    private function transform(SmtpSetting $setting): array
+    {
+        return [
+            'id' => $setting->id,
+            'host' => $setting->host,
+            'port' => $setting->port,
+            'username' => $setting->username,
+            'password' => '********',
+            'encryption' => $setting->encryption,
+            'from_name' => $setting->from_name,
+            'from_email' => $setting->from_email,
+            'reply_to' => $setting->reply_to,
+            'is_active' => $setting->is_active,
+        ];
+    }
+}

--- a/app/Mail/TestSmtpMail.php
+++ b/app/Mail/TestSmtpMail.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use Illuminate\Mail\Mailable;
+
+class TestSmtpMail extends Mailable
+{
+    public function build(): static
+    {
+        return $this->subject('SMTP Test')->text('mail.test-smtp');
+    }
+}

--- a/app/Services/Mail/MailerResolver.php
+++ b/app/Services/Mail/MailerResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mail;
+
+use App\Models\Workspace;
+use Illuminate\Contracts\Mail\Factory as MailFactory;
+use Illuminate\Contracts\Mail\Mailer as MailerContract;
+
+class MailerResolver
+{
+    public function __construct(private MailFactory $factory) {}
+
+    public function for(Workspace $workspace): MailerContract
+    {
+        $setting = $workspace->smtpSettings()->where('is_active', true)->first();
+
+        if ($setting === null) {
+            return $this->factory->mailer();
+        }
+
+        $name = 'workspace-'.$workspace->id;
+
+        if (! config()->has("mail.mailers.$name")) {
+            config([
+                "mail.mailers.$name" => [
+                    'transport' => 'smtp',
+                    'host' => $setting->host,
+                    'port' => $setting->port,
+                    'username' => $setting->username,
+                    'password' => decrypt($setting->password_encrypted),
+                    'scheme' => $setting->encryption,
+                ],
+            ]);
+        }
+
+        $mailer = $this->factory->mailer($name);
+
+        if ($setting->from_email !== null) {
+            $mailer->alwaysFrom($setting->from_email, $setting->from_name);
+        }
+
+        if ($setting->reply_to !== null) {
+            $mailer->alwaysReplyTo($setting->reply_to);
+        }
+
+        return $mailer;
+    }
+}

--- a/resources/views/mail/test-smtp.blade.php
+++ b/resources/views/mail/test-smtp.blade.php
@@ -1,0 +1,1 @@
+SMTP test successful.

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,10 +3,17 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\AuthTokenController;
+use App\Http\Controllers\SmtpSettingsController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/auth/token', AuthTokenController::class)->middleware('workspace');
 
-Route::middleware(['auth:sanctum', 'workspace'])->get('/ping', function () {
-    return response()->json(['data' => ['pong' => true]]);
+Route::middleware(['auth:sanctum', 'workspace'])->group(function (): void {
+    Route::get('/ping', function () {
+        return response()->json(['data' => ['pong' => true]]);
+    });
+
+    Route::get('/smtp-settings', [SmtpSettingsController::class, 'show']);
+    Route::post('/smtp-settings', [SmtpSettingsController::class, 'store']);
+    Route::post('/smtp-settings/test', [SmtpSettingsController::class, 'test']);
 });

--- a/tests/Feature/SmtpSettingsTest.php
+++ b/tests/Feature/SmtpSettingsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Mail\TestSmtpMail;
+use App\Models\SmtpSetting;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+function authHeaders(User $user, Workspace $workspace): array
+{
+    $token = $user->createToken('api')->plainTextToken;
+
+    return [
+        'Authorization' => "Bearer {$token}",
+        'X-Workspace' => $workspace->slug,
+    ];
+}
+
+it('stores settings encrypting password', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+
+    $response = postJson('/api/smtp-settings', [
+        'host' => 'smtp.example.com',
+        'port' => 587,
+        'username' => 'jane',
+        'password' => 'secret',
+        'encryption' => 'tls',
+        'from_name' => 'Jane',
+        'from_email' => 'jane@example.com',
+        'reply_to' => 'reply@example.com',
+    ], authHeaders($user, $workspace));
+
+    $response->assertOk();
+
+    $setting = SmtpSetting::first();
+    expect($setting->password_encrypted)->not->toBe('secret')
+        ->and(decrypt($setting->password_encrypted))->toBe('secret');
+});
+
+it('shows masked password on fetch', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+    SmtpSetting::factory()->for($workspace)->create([
+        'password_encrypted' => encrypt('super-secret'),
+    ]);
+
+    $response = getJson('/api/smtp-settings', authHeaders($user, $workspace));
+
+    $response->assertOk()
+        ->assertJsonPath('data.password', '********');
+});
+
+it('can test smtp settings sending mail', function (): void {
+    Mail::fake();
+
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+    SmtpSetting::factory()->for($workspace)->create([
+        'password_encrypted' => encrypt('secret'),
+    ]);
+
+    $response = postJson('/api/smtp-settings/test', [
+        'to' => 'test@example.com',
+    ], authHeaders($user, $workspace));
+
+    $response->assertOk()
+        ->assertJsonPath('data.sent', true);
+
+    Mail::assertSent(TestSmtpMail::class, function (TestSmtpMail $mail) {
+        return $mail->hasTo('test@example.com');
+    });
+});


### PR DESCRIPTION
## Summary
- add API to save, view, and test workspace SMTP settings with encrypted passwords
- resolve mailers from workspace configuration with .env fallback
- scaffold Filament resource for managing SMTP settings

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc0c5634d8832b8f2f9a4e8753711c