### PR TITLE
feat: add contacts upsert and import API

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Contact;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ContactController extends Controller
+{
+    public function upsert(Request $request): Response
+    {
+        $data = $request->validate([
+            'email' => ['required', 'email'],
+            'first_name' => ['nullable', 'string'],
+            'last_name' => ['nullable', 'string'],
+            'attributes' => ['nullable', 'array'],
+        ]);
+
+        $contact = Contact::updateOrCreate(
+            [
+                'workspace_id' => currentWorkspace()->id,
+                'email' => $data['email'],
+            ],
+            [
+                'first_name' => $data['first_name'] ?? null,
+                'last_name' => $data['last_name'] ?? null,
+                'attributes' => $data['attributes'] ?? [],
+            ],
+        );
+
+        return response()->json(
+            ['data' => $this->transform($contact)],
+            $contact->wasRecentlyCreated ? 201 : 200,
+        );
+    }
+
+    public function bulkImport(Request $request): Response
+    {
+        $records = str_contains($request->header('Content-Type', ''), 'json')
+            ? $request->json()->all()
+            : $this->parseCsv($request->getContent());
+
+        $created = 0;
+        $updated = 0;
+        $errors = [];
+
+        foreach ($records as $index => $row) {
+            $email = $row['email'] ?? null;
+
+            if (!is_string($email) || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                $errors[] = ['row' => $index, 'message' => 'Invalid email'];
+
+                continue;
+            }
+
+            $contact = Contact::updateOrCreate(
+                [
+                    'workspace_id' => currentWorkspace()->id,
+                    'email' => $email,
+                ],
+                [
+                    'first_name' => $row['first_name'] ?? null,
+                    'last_name' => $row['last_name'] ?? null,
+                    'attributes' => array_diff_key(
+                        $row,
+                        array_flip(['email', 'first_name', 'last_name']),
+                    ),
+                ],
+            );
+
+            if ($contact->wasRecentlyCreated) {
+                $created++;
+
+                continue;
+            }
+
+            $updated++;
+        }
+
+        return response()->json([
+            'data' => [
+                'created' => $created,
+                'updated' => $updated,
+                'errors' => $errors,
+            ],
+        ]);
+    }
+
+    private function parseCsv(string $csv): array
+    {
+        $rows = array_filter(array_map('trim', explode("\n", $csv)));
+
+        if ($rows === []) {
+            return [];
+        }
+
+        $header = str_getcsv(array_shift($rows));
+        $records = [];
+
+        foreach ($rows as $row) {
+            if ($row === '') {
+                continue;
+            }
+
+            $columns = str_getcsv($row);
+
+            if (count($columns) !== count($header)) {
+                continue;
+            }
+
+            $records[] = array_combine($header, $columns);
+        }
+
+        return $records;
+    }
+
+    private function transform(Contact $contact): array
+    {
+        return [
+            'id' => $contact->id,
+            'email' => $contact->email,
+            'first_name' => $contact->first_name,
+            'last_name' => $contact->last_name,
+            'attributes' => $contact->attributes,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\AuthTokenController;
+use App\Http\Controllers\ContactController;
 use App\Http\Controllers\SmtpSettingsController;
 use Illuminate\Support\Facades\Route;
 
@@ -16,4 +17,7 @@ Route::middleware(['auth:sanctum', 'workspace'])->group(function (): void {
     Route::get('/smtp-settings', [SmtpSettingsController::class, 'show']);
     Route::post('/smtp-settings', [SmtpSettingsController::class, 'store']);
     Route::post('/smtp-settings/test', [SmtpSettingsController::class, 'test']);
+
+    Route::post('/contacts', [ContactController::class, 'upsert']);
+    Route::post('/contacts/import', [ContactController::class, 'bulkImport']);
 });

--- a/tests/Feature/ContactsApiTest.php
+++ b/tests/Feature/ContactsApiTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Contact;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+if (!function_exists('authHeaders')) {
+    function authHeaders(User $user, Workspace $workspace): array
+    {
+        $token = $user->createToken('api')->plainTextToken;
+
+        return [
+            'Authorization' => "Bearer {$token}",
+            'X-Workspace' => $workspace->slug,
+        ];
+    }
+}
+
+it('upsert creates contact', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+
+    $response = postJson('/api/contacts', [
+        'email' => 'jane@example.com',
+        'first_name' => 'Jane',
+    ], authHeaders($user, $workspace));
+
+    $response->assertCreated()
+        ->assertJsonPath('data.email', 'jane@example.com');
+
+    expect(Contact::where('workspace_id', $workspace->id)->count())->toBe(1);
+});
+
+it('upsert updates existing contact on second call', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+
+    postJson('/api/contacts', [
+        'email' => 'jane@example.com',
+        'first_name' => 'Jane',
+    ], authHeaders($user, $workspace));
+
+    $response = postJson('/api/contacts', [
+        'email' => 'jane@example.com',
+        'first_name' => 'Janet',
+    ], authHeaders($user, $workspace));
+
+    $response->assertOk()
+        ->assertJsonPath('data.first_name', 'Janet');
+
+    expect(Contact::where('workspace_id', $workspace->id)->count())->toBe(1)
+        ->and(Contact::first()->first_name)->toBe('Janet');
+});
+
+it('bulk import returns counts', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+    Contact::factory()->for($workspace)->create(['email' => 'jane@example.com']);
+
+    $payload = [
+        ['email' => 'jane@example.com', 'first_name' => 'Janet'],
+        ['email' => 'john@example.com', 'first_name' => 'John'],
+    ];
+
+    $response = postJson('/api/contacts/import', $payload, authHeaders($user, $workspace));
+
+    $response->assertOk()
+        ->assertJsonPath('data.created', 1)
+        ->assertJsonPath('data.updated', 1)
+        ->assertJsonPath('data.errors', []);
+
+    expect(Contact::where('workspace_id', $workspace->id)->count())->toBe(2)
+        ->and(Contact::where('email', 'jane@example.com')->first()->first_name)->toBe('Janet');
+});

--- a/tests/Feature/SmtpSettingsTest.php
+++ b/tests/Feature/SmtpSettingsTest.php
@@ -14,14 +14,16 @@ use function Pest\Laravel\postJson;
 
 uses(RefreshDatabase::class);
 
-function authHeaders(User $user, Workspace $workspace): array
-{
-    $token = $user->createToken('api')->plainTextToken;
+if (!function_exists('authHeaders')) {
+    function authHeaders(User $user, Workspace $workspace): array
+    {
+        $token = $user->createToken('api')->plainTextToken;
 
-    return [
-        'Authorization' => "Bearer {$token}",
-        'X-Workspace' => $workspace->slug,
-    ];
+        return [
+            'Authorization' => "Bearer {$token}",
+            'X-Workspace' => $workspace->slug,
+        ];
+    }
 }
 
 it('stores settings encrypting password', function (): void {


### PR DESCRIPTION
## Summary
- add Contacts API with upsert and bulk import (CSV/JSON)
- expose endpoints via /api/contacts and /api/contacts/import
- add tests covering upsert and bulk import flows

## Testing
- `vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68bc0eecae98832bbf1af44d7e448f92