### PR TITLE
Add event ingestion endpoint

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Jobs\ProcessEvent;
+use App\Models\Contact;
+use App\Models\Event;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Symfony\Component\HttpFoundation\Response;
+
+class EventController extends Controller
+{
+    public function ingest(Request $request): Response
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string'],
+            'payload' => ['nullable', 'array'],
+            'contact_email' => ['nullable', 'email'],
+            'occurred_at' => ['nullable', 'date'],
+            'auto_create_contact' => ['nullable', 'boolean'],
+        ]);
+
+        $contact = null;
+
+        if (isset($data['contact_email'])) {
+            $contact = Contact::where('workspace_id', currentWorkspace()->id)
+                ->where('email', $data['contact_email'])
+                ->first();
+
+            if ($contact === null && ($data['auto_create_contact'] ?? false)) {
+                $contact = Contact::create([
+                    'workspace_id' => currentWorkspace()->id,
+                    'email' => $data['contact_email'],
+                ]);
+            }
+        }
+
+        $event = Event::create([
+            'workspace_id' => currentWorkspace()->id,
+            'name' => $data['name'],
+            'contact_id' => $contact?->id,
+            'payload' => $data['payload'] ?? [],
+            'occurred_at' => isset($data['occurred_at'])
+                ? Carbon::parse($data['occurred_at'])
+                : now(),
+        ]);
+
+        ProcessEvent::dispatch($event);
+
+        return response()->json([
+            'data' => [
+                'id' => $event->id,
+            ],
+        ], 201);
+    }
+}

--- a/app/Jobs/ProcessEvent.php
+++ b/app/Jobs/ProcessEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\Event;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessEvent implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public Event $event) {}
+
+    public function handle(): void
+    {
+        //
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\AuthTokenController;
 use App\Http\Controllers\ContactController;
+use App\Http\Controllers\EventController;
 use App\Http\Controllers\SmtpSettingsController;
 use App\Http\Controllers\TemplateController;
 use Illuminate\Support\Facades\Route;
@@ -21,6 +22,8 @@ Route::middleware(['auth:sanctum', 'workspace'])->group(function (): void {
 
     Route::post('/contacts', [ContactController::class, 'upsert']);
     Route::post('/contacts/import', [ContactController::class, 'bulkImport']);
+
+    Route::post('/events', [EventController::class, 'ingest']);
 
     Route::apiResource('templates', TemplateController::class);
     Route::post('/templates/{template}/preview', [TemplateController::class, 'preview']);

--- a/tests/Feature/EventsIngestionTest.php
+++ b/tests/Feature/EventsIngestionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\ProcessEvent;
+use App\Models\Contact;
+use App\Models\Event;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+if (! function_exists('authHeaders')) {
+    function authHeaders(User $user, Workspace $workspace): array
+    {
+        $token = $user->createToken('api')->plainTextToken;
+
+        return [
+            'Authorization' => "Bearer {$token}",
+            'X-Workspace' => $workspace->slug,
+        ];
+    }
+}
+
+it('stores event, links contact, and dispatches job', function (): void {
+    Bus::fake();
+
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+
+    $response = postJson('/api/events', [
+        'name' => 'user.signed_up',
+        'contact_email' => 'jane@example.com',
+        'payload' => ['plan' => 'pro'],
+        'auto_create_contact' => true,
+    ], authHeaders($user, $workspace));
+
+    $response->assertCreated();
+
+    $contact = Contact::where('workspace_id', $workspace->id)->first();
+    expect($contact)->not->toBeNull();
+
+    $event = Event::first();
+
+    expect($event->contact_id)->toBe($contact->id)
+        ->and($event->name)->toBe('user.signed_up')
+        ->and($event->payload)->toBe(['plan' => 'pro']);
+
+    Bus::assertDispatched(ProcessEvent::class, function (ProcessEvent $job) use ($event) {
+        return $job->event->is($event);
+    });
+});


### PR DESCRIPTION
## Summary
- add event ingestion controller and job
- queue processing after storing events and resolving contacts
- cover event ingestion with feature test

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc1b1b1c70832baebde56ff7f14586