### PR TITLE
Add automation condition evaluator and validator

### DIFF
--- a/app/Domain/Automation/AutomationValidator.php
+++ b/app/Domain/Automation/AutomationValidator.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Automation;
+
+use InvalidArgumentException;
+
+class AutomationValidator
+{
+    /**
+     * @param array<int, array{uid: string, next_step_uid: ?string, alt_next_step_uid: ?string}> $steps
+     */
+    public function validate(array $steps): void
+    {
+        $uids = array_column($steps, 'uid');
+
+        foreach ($steps as $step) {
+            foreach (['next_step_uid', 'alt_next_step_uid'] as $key) {
+                $target = $step[$key] ?? null;
+                if ($target !== null && ! in_array($target, $uids, true)) {
+                    throw new InvalidArgumentException("Invalid reference to {$target}");
+                }
+            }
+        }
+
+        $graph = [];
+        foreach ($steps as $step) {
+            $graph[$step['uid']] = array_filter([
+                $step['next_step_uid'] ?? null,
+                $step['alt_next_step_uid'] ?? null,
+            ]);
+        }
+
+        $visited = [];
+        $stack = [];
+
+        $visit = function (string $uid) use (&$visit, &$visited, &$stack, $graph): void {
+            if (isset($stack[$uid])) {
+                throw new InvalidArgumentException('Cycle detected');
+            }
+
+            if (isset($visited[$uid])) {
+                return;
+            }
+
+            $visited[$uid] = true;
+            $stack[$uid] = true;
+
+            foreach ($graph[$uid] ?? [] as $next) {
+                $visit($next);
+            }
+
+            unset($stack[$uid]);
+        };
+
+        foreach (array_keys($graph) as $uid) {
+            $visit($uid);
+        }
+    }
+}

--- a/app/Domain/Automation/ConditionsEvaluator.php
+++ b/app/Domain/Automation/ConditionsEvaluator.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Automation;
+
+use Illuminate\Support\Arr;
+
+class ConditionsEvaluator
+{
+    public function evaluate(array $conditions, array $contact, array $event): bool
+    {
+        $data = ['contact' => $contact, 'event' => $event];
+
+        foreach ($conditions as $condition) {
+            $path = $condition['path'] ?? null;
+            $operator = $condition['op'] ?? null;
+            $value = $condition['value'] ?? null;
+            $actual = data_get($data, $path);
+
+            switch ($operator) {
+                case '==':
+                    if ($actual !== $value) {
+                        return false;
+                    }
+
+                    break;
+                case '!=':
+                    if ($actual === $value) {
+                        return false;
+                    }
+
+                    break;
+                case 'in':
+                    if (! is_array($value) || ! in_array($actual, $value, true)) {
+                        return false;
+                    }
+
+                    break;
+                case '<=':
+                    if (! ($actual <= $value)) {
+                        return false;
+                    }
+
+                    break;
+                case '>=':
+                    if (! ($actual >= $value)) {
+                        return false;
+                    }
+
+                    break;
+                case '<':
+                    if (! ($actual < $value)) {
+                        return false;
+                    }
+
+                    break;
+                case '>':
+                    if (! ($actual > $value)) {
+                        return false;
+                    }
+
+                    break;
+                case 'exists':
+                    if (! Arr::has($data, $path)) {
+                        return false;
+                    }
+
+                    break;
+                case 'contains':
+                    if (is_array($actual)) {
+                        if (! in_array($value, $actual, true)) {
+                            return false;
+                        }
+                    } elseif (is_string($actual) && is_string($value)) {
+                        if (! str_contains($actual, $value)) {
+                            return false;
+                        }
+                    } else {
+                        return false;
+                    }
+
+                    break;
+                default:
+                    return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Unit/AutomationValidatorTest.php
+++ b/tests/Unit/AutomationValidatorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Automation\AutomationValidator;
+
+it('rejects missing step references', function () {
+    $validator = new AutomationValidator();
+    $steps = [
+        ['uid' => 'a', 'next_step_uid' => 'missing', 'alt_next_step_uid' => null],
+    ];
+
+    expect(fn () => $validator->validate($steps))->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects cycles', function () {
+    $validator = new AutomationValidator();
+    $steps = [
+        ['uid' => 'a', 'next_step_uid' => 'b', 'alt_next_step_uid' => null],
+        ['uid' => 'b', 'next_step_uid' => 'a', 'alt_next_step_uid' => null],
+    ];
+
+    expect(fn () => $validator->validate($steps))->toThrow(InvalidArgumentException::class);
+});
+
+it('accepts valid graphs', function () {
+    $validator = new AutomationValidator();
+    $steps = [
+        ['uid' => 'a', 'next_step_uid' => 'b', 'alt_next_step_uid' => null],
+        ['uid' => 'b', 'next_step_uid' => null, 'alt_next_step_uid' => null],
+    ];
+
+    expect(fn () => $validator->validate($steps))->not->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Unit/ConditionsEvaluatorTest.php
+++ b/tests/Unit/ConditionsEvaluatorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Automation\ConditionsEvaluator;
+
+it('evaluates equality operator', function () {
+    $evaluator = new ConditionsEvaluator();
+    $condition = ['path' => 'contact.age', 'op' => '==', 'value' => 30];
+
+    $true = $evaluator->evaluate([$condition], ['age' => 30], []);
+    $false = $evaluator->evaluate([$condition], ['age' => 25], []);
+
+    expect($true)->toBeTrue()->and($false)->toBeFalse();
+});
+
+it('evaluates inequality operator', function () {
+    $evaluator = new ConditionsEvaluator();
+    $condition = ['path' => 'contact.age', 'op' => '!=', 'value' => 30];
+
+    $true = $evaluator->evaluate([$condition], ['age' => 25], []);
+    $false = $evaluator->evaluate([$condition], ['age' => 30], []);
+
+    expect($true)->toBeTrue()->and($false)->toBeFalse();
+});
+
+it('evaluates in operator', function () {
+    $evaluator = new ConditionsEvaluator();
+    $condition = ['path' => 'event.type', 'op' => 'in', 'value' => ['open', 'click']];
+
+    $true = $evaluator->evaluate([$condition], [], ['type' => 'open']);
+    $false = $evaluator->evaluate([$condition], [], ['type' => 'bounce']);
+
+    expect($true)->toBeTrue()->and($false)->toBeFalse();
+});
+
+it('evaluates less than or equal operator', function () {
+    $evaluator = new ConditionsEvaluator();
+    $condition = ['path' => 'contact.score', 'op' => '<=', 'value' => 10];
+
+    $true = $evaluator->evaluate([$condition], ['score' => 5], []);
+    $false = $evaluator->evaluate([$condition], ['score' => 15], []);
+
+    expect($true)->toBeTrue()->and($false)->toBeFalse();
+});
+
+it('evaluates greater than or equal operator', function () {
+    $evaluator = new ConditionsEvaluator();
+    $condition = ['path' => 'contact.score', 'op' => '>=', 'value' => 10];
+
+    $true = $evaluator->evaluate([$condition], ['score' => 10], []);
+    $false = $evaluator->evaluate([$condition], ['score' => 5], []);
+
+    expect($true)->toBeTrue()->and($false)->toBeFalse();
+});
+
+it('evaluates less than operator', function () {
+    $evaluator = new ConditionsEvaluator();
+    $condition = ['path' => 'contact.score', 'op' => '<', 'value' => 10];
+
+    $true = $evaluator->evaluate([$condition], ['score' => 5], []);
+    $false = $evaluator->evaluate([$condition], ['score' => 10], []);
+
+    expect($true)->toBeTrue()->and($false)->toBeFalse();
+});
+
+it('evaluates greater than operator', function () {
+    $evaluator = new ConditionsEvaluator();
+    $condition = ['path' => 'contact.score', 'op' => '>', 'value' => 5];
+
+    $true = $evaluator->evaluate([$condition], ['score' => 10], []);
+    $false = $evaluator->evaluate([$condition], ['score' => 5], []);
+
+    expect($true)->toBeTrue()->and($false)->toBeFalse();
+});
+
+it('evaluates exists operator', function () {
+    $evaluator = new ConditionsEvaluator();
+    $condition = ['path' => 'contact.email', 'op' => 'exists'];
+
+    $true = $evaluator->evaluate([$condition], ['email' => 'a@example.com'], []);
+    $false = $evaluator->evaluate([$condition], [], []);
+
+    expect($true)->toBeTrue()->and($false)->toBeFalse();
+});
+
+it('evaluates contains operator', function () {
+    $evaluator = new ConditionsEvaluator();
+    $condition = ['path' => 'contact.tags', 'op' => 'contains', 'value' => 'news'];
+
+    $true = $evaluator->evaluate([$condition], ['tags' => ['news', 'sale']], []);
+    $false = $evaluator->evaluate([$condition], ['tags' => ['sale']], []);
+
+    expect($true)->toBeTrue()->and($false)->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- add `ConditionsEvaluator` supporting equality, comparison, membership and existence operators
- add `AutomationValidator` that checks step references and prevents graph cycles
- cover evaluator operators and invalid step references with unit tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc1d11fa24832b841717b24195ceeb