### PR TITLE
Handle bounce and complaint webhooks

### DIFF
--- a/app/Http/Controllers/Webhooks/PostmarkController.php
+++ b/app/Http/Controllers/Webhooks/PostmarkController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Webhooks;
+
+use App\Enums\ContactStatus;
+use App\Enums\DeliveryStatus;
+use App\Enums\SuppressionReason;
+use App\Models\Delivery;
+use App\Models\Suppression;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class PostmarkController
+{
+    public function __invoke(Request $request): Response
+    {
+        $data = $request->json()->all();
+
+        $type = $data['RecordType'] ?? null;
+        $messageId = $data['MessageID'] ?? null;
+        $email = $data['Email'] ?? null;
+
+        if ($type === null || $messageId === null || $email === null) {
+            return response()->json(['ok' => true]);
+        }
+
+        $delivery = Delivery::where('provider_message_id', $messageId)->first();
+
+        if ($delivery === null) {
+            return response()->json(['ok' => true]);
+        }
+
+        $reason = match ($type) {
+            'Bounce' => SuppressionReason::Bounce,
+            'SpamComplaint' => SuppressionReason::Complaint,
+            default => null,
+        };
+
+        if ($reason === null) {
+            return response()->json(['ok' => true]);
+        }
+
+        Suppression::updateOrCreate(
+            [
+                'workspace_id' => $delivery->workspace_id,
+                'email' => $email,
+            ],
+            [
+                'reason' => $reason,
+                'source' => $data,
+            ]
+        );
+
+        $contact = $delivery->contact;
+        $contact->status = $reason === SuppressionReason::Bounce
+            ? ContactStatus::Bounced
+            : ContactStatus::Complained;
+        $contact->save();
+
+        $delivery->status = $reason === SuppressionReason::Bounce
+            ? DeliveryStatus::Bounced
+            : DeliveryStatus::Complained;
+        $delivery->save();
+
+        return response()->json(['ok' => true]);
+    }
+}

--- a/app/Http/Controllers/Webhooks/SesController.php
+++ b/app/Http/Controllers/Webhooks/SesController.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Webhooks;
+
+use App\Enums\ContactStatus;
+use App\Enums\DeliveryStatus;
+use App\Enums\SuppressionReason;
+use App\Models\Delivery;
+use App\Models\Suppression;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SesController
+{
+    public function __invoke(Request $request): Response
+    {
+        $data = $request->json()->all();
+
+        $type = $data['eventType'] ?? $data['notificationType'] ?? null;
+        $messageId = $data['mail']['messageId'] ?? null;
+        $recipients = [];
+        if (isset($data['bounce']['bouncedRecipients'])) {
+            $recipients = $data['bounce']['bouncedRecipients'];
+        } elseif (isset($data['complaint']['complainedRecipients'])) {
+            $recipients = $data['complaint']['complainedRecipients'];
+        }
+        $email = $recipients[0]['emailAddress'] ?? null;
+
+        if ($type === null || $messageId === null || $email === null) {
+            return response()->json(['ok' => true]);
+        }
+
+        $delivery = Delivery::where('provider_message_id', $messageId)->first();
+        if ($delivery === null) {
+            return response()->json(['ok' => true]);
+        }
+
+        $reason = match ($type) {
+            'Bounce' => SuppressionReason::Bounce,
+            'Complaint' => SuppressionReason::Complaint,
+            default => null,
+        };
+
+        if ($reason === null) {
+            return response()->json(['ok' => true]);
+        }
+
+        Suppression::updateOrCreate(
+            [
+                'workspace_id' => $delivery->workspace_id,
+                'email' => $email,
+            ],
+            [
+                'reason' => $reason,
+                'source' => $data,
+            ]
+        );
+
+        $contact = $delivery->contact;
+        $contact->status = $reason === SuppressionReason::Bounce
+            ? ContactStatus::Bounced
+            : ContactStatus::Complained;
+        $contact->save();
+
+        $delivery->status = $reason === SuppressionReason::Bounce
+            ? DeliveryStatus::Bounced
+            : DeliveryStatus::Complained;
+        $delivery->save();
+
+        return response()->json(['ok' => true]);
+    }
+}

--- a/app/Services/Mail/MailerResolver.php
+++ b/app/Services/Mail/MailerResolver.php
@@ -4,23 +4,43 @@ declare(strict_types=1);
 
 namespace App\Services\Mail;
 
+use App\Models\Contact;
+use App\Models\Suppression;
 use App\Models\Workspace;
 use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
+use Illuminate\Contracts\Queue\Factory as QueueFactory;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Mail\Mailer as IlluminateMailer;
+use Illuminate\Mail\Transport\NullTransport;
 
 class MailerResolver
 {
-    public function __construct(private MailFactory $factory) {}
+    public function __construct(
+        private MailFactory $factory,
+        private ViewFactory $views,
+        private QueueFactory $queue,
+    ) {}
 
-    public function for(Workspace $workspace): MailerContract
+    public function for(Workspace $workspace, ?Contact $contact = null): MailerContract
     {
+        if ($contact !== null) {
+            $suppressed = Suppression::where('workspace_id', $workspace->id)
+                ->where('email', $contact->email)
+                ->exists();
+
+            if ($suppressed) {
+                return new IlluminateMailer('null', $this->views, new NullTransport(), $this->queue);
+            }
+        }
+
         $setting = $workspace->smtpSettings()->where('is_active', true)->first();
 
         if ($setting === null) {
             return $this->factory->mailer();
         }
 
-        $name = 'workspace-'.$workspace->id;
+        $name = 'workspace-' . $workspace->id;
 
         if (! config()->has("mail.mailers.$name")) {
             config([

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\TrackingController;
+use App\Http\Controllers\Webhooks\PostmarkController;
+use App\Http\Controllers\Webhooks\SesController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/health', fn () => response()->json(['ok' => true]));
@@ -8,6 +10,9 @@ Route::get('/health', fn () => response()->json(['ok' => true]));
 Route::get('/t/o/{token}', [TrackingController::class, 'open']);
 Route::get('/t/c/{token}', [TrackingController::class, 'click']);
 Route::get('/t/u/{token}', [TrackingController::class, 'unsubscribe']);
+
+Route::post('/webhooks/postmark', PostmarkController::class);
+Route::post('/webhooks/ses', SesController::class);
 
 Route::get('/', function () {
     return view('welcome');

--- a/tests/Feature/WebhooksSuppressionTest.php
+++ b/tests/Feature/WebhooksSuppressionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ContactStatus;
+use App\Enums\DeliveryStatus;
+use App\Enums\SuppressionReason;
+use App\Mail\TemplateTestMail;
+use App\Models\Automation;
+use App\Models\Contact;
+use App\Models\Delivery;
+use App\Models\Template;
+use App\Models\User;
+use App\Models\Workspace;
+use App\Services\Mail\MailerResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+if (! function_exists('authHeaders')) {
+    function authHeaders(User $user, Workspace $workspace): array
+    {
+        $token = $user->createToken('api')->plainTextToken;
+
+        return [
+            'Authorization' => "Bearer {$token}",
+            'X-Workspace' => $workspace->slug,
+        ];
+    }
+}
+
+it('suppresses contact on postmark bounce webhook', function (): void {
+    $workspace = Workspace::factory()->create();
+    $contact = Contact::factory()->for($workspace)->create([
+        'email' => 'john@example.com',
+    ]);
+    $template = Template::factory()->for($workspace)->create();
+    $automation = Automation::factory()->for($workspace)->create();
+    $delivery = Delivery::factory()->for($workspace)->for($contact)->for($template)->for($automation)->create([
+        'provider_message_id' => 'abc-123',
+        'status' => DeliveryStatus::Sent,
+    ]);
+
+    $payload = json_decode(file_get_contents(base_path('tests/fixtures/postmark-bounce.json')), true);
+    $payload['MessageID'] = 'abc-123';
+    $payload['Email'] = 'john@example.com';
+
+    $response = postJson('/webhooks/postmark', $payload);
+    $response->assertOk();
+
+    expect($contact->fresh()->status)->toBe(ContactStatus::Bounced)
+        ->and($delivery->fresh()->status)->toBe(DeliveryStatus::Bounced)
+        ->and($workspace->suppressions()->where('email', 'john@example.com')->exists())->toBeTrue();
+});
+
+it('skips sending to suppressed contact', function (): void {
+    Mail::fake();
+
+    $workspace = Workspace::factory()->create();
+    $contact = Contact::factory()->for($workspace)->create([
+        'email' => 'john@example.com',
+    ]);
+    $workspace->suppressions()->create([
+        'email' => 'john@example.com',
+        'reason' => SuppressionReason::Bounce,
+        'source' => [],
+    ]);
+
+    $resolver = app(MailerResolver::class);
+    $mailer = $resolver->for($workspace, $contact);
+    $mailer->to($contact->email)->queue(new TemplateTestMail('Test', '<p>Hi</p>', 'Hi'));
+
+    Mail::assertNothingQueued();
+});

--- a/tests/fixtures/postmark-bounce.json
+++ b/tests/fixtures/postmark-bounce.json
@@ -1,0 +1,7 @@
+{
+  "MessageID": "example-id",
+  "RecordType": "Bounce",
+  "Type": "HardBounce",
+  "TypeCode": 1,
+  "Email": "example@example.com"
+}

--- a/tests/fixtures/ses-bounce.json
+++ b/tests/fixtures/ses-bounce.json
@@ -1,0 +1,8 @@
+{
+  "eventType": "Bounce",
+  "mail": {"messageId": "example-id"},
+  "bounce": {
+    "bounceType": "Permanent",
+    "bouncedRecipients": [{"emailAddress": "example@example.com"}]
+  }
+}


### PR DESCRIPTION
## Summary
- handle Postmark and SES webhook callbacks to create suppressions and update contact and delivery statuses
- skip sending mail to suppressed contacts via MailerResolver
- test webhook suppression flow and suppression-aware sending

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc21aeee58832b8da45819ed5b7182