### PR TITLE
docs: expand usage guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,12 @@
 # Trigger Engage Guidelines
 
 ## Product Vision
-Trigger Engage is an open-source, self-hosted, event-driven email automation tool. It empowers teams to build and run email workflows on their own infrastructure.
+Trigger Engage is an open-source, self-hosted, event-driven messaging automation tool. It empowers teams to build and run email and push notification workflows on their own infrastructure.
+Workspaces keep contacts, templates, automations, and device tokens isolated, and events trigger those automations through a JSON:API interface.
 
 ## Architecture
 - **Domain**: Core business logic and aggregates.
-- **Services**: Cross-cutting services and integrations (mail, queue, etc.).
+- **Services**: Cross-cutting services and integrations (mail, push, queue, etc.).
 - **Http**: Controllers, requests, and routes.
 - **Middleware**: HTTP middleware.
 
@@ -20,3 +21,11 @@ Trigger Engage is an open-source, self-hosted, event-driven email automation too
 2. **Green** – write the minimal code to make the test pass.
 3. **Refactor** – improve the implementation while keeping tests green.
 Commit only when tests are green.
+
+## Getting Started
+1. `composer install` and `npm install` to fetch dependencies.
+2. Copy `.env.example` to `.env`, run `php artisan key:generate`, and configure PostgreSQL and Redis.
+3. Run migrations with `php artisan migrate` and seed demo data with `php artisan make:demo`.
+4. Start queues with `php artisan horizon` and the scheduler with `php artisan schedule:work`.
+5. Optional: configure push notification drivers (Expo or OneSignal) in Filament and register device tokens via the API.
+6. Use `php artisan serve` to run the app locally and `php artisan test` to execute the test suite.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # Trigger Engage
 
 Trigger Engage is an open-source, self-hosted, event-driven email automation tool built on Laravel.
+It lets you define reusable email workflows that react to arbitrary events and send templated messages.
+Workspaces isolate contacts, templates, and automations so multiple teams can share a single installation
+while keeping data separate.
+
+## Features
+- Event-driven workflow engine for automating emails.
+- Push notification delivery via drivers like Expo or OneSignal.
+- JSON:API compliant endpoints for integrating with any client.
+- Horizon-powered Redis queues and a scheduler for timed tasks.
+- Demo seeder and health check to explore the API quickly.
 
 ## Requirements
 - PHP 8.3+
@@ -41,6 +51,25 @@ To run the scheduler via cron in production, add:
 ```cron
 * * * * * cd /path/to/trigger-engage && php artisan schedule:run >> /dev/null 2>&1
 ```
+
+## Usage
+With queues and the scheduler running, send named events to the API to trigger automations.  
+Each event belongs to a workspace and may include contact information. Automations listen for these
+events and dispatch emails or other jobs through the queue.
+
+## Push Notifications
+To send pushes:
+1. Configure push settings for your workspace (Expo or OneSignal) via the Filament admin panel.
+2. Register device tokens for contacts:
+   ```bash
+   curl -X POST http://localhost/api/contacts/{contact_id}/device-tokens \
+     -H "Authorization: Bearer <token>" \
+     -H "X-Workspace: demo" \
+     -H "Content-Type: application/json" \
+     -d '{"token":"ExponentPushToken[xxx]","driver":"expo"}'
+   ```
+3. Add a **Send Push Notification** step to an automation with a templated title and body.
+4. Ingest events as shown above to queue and deliver the notification.
 
 ## Demo Data
 Seed a workspace with a contact, template, and automation:


### PR DESCRIPTION
## Summary
- elaborate on Trigger Engage features and workflow usage in README
- add setup and usage guidance for contributors in AGENTS.md
- document push notification support and provide setup guide

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2b76b624832bae6f508313942b51