### PR TITLE
feat: add admin stats dashboard

### DIFF
--- a/app/Filament/AdminPanelProvider.php
+++ b/app/Filament/AdminPanelProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament;
+
+use App\Http\Middleware\EnsureUserIsAdmin;
+use Filament\Http\Middleware\Authenticate;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Pages;
+use Filament\Support\Colors\Color;
+
+class AdminPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->default()
+            ->id('admin')
+            ->path('admin')
+            ->login()
+            ->colors([
+                'primary' => Color::Indigo,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+                EnsureUserIsAdmin::class,
+            ])
+            ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
+            ->pages([
+                Pages\Dashboard::class,
+            ]);
+    }
+}

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages;
+
+use Filament\Pages\Dashboard as BaseDashboard;
+
+class Dashboard extends BaseDashboard
+{
+    public function getWidgets(): array
+    {
+        return [
+            \App\Filament\Widgets\StatsOverview::class,
+            \App\Filament\Widgets\DeliveriesPerDayChart::class,
+            \App\Filament\Widgets\BounceComplaintChart::class,
+            \App\Filament\Widgets\TopAutomationsChart::class,
+            \App\Filament\Widgets\HorizonHealthWidget::class,
+        ];
+    }
+}

--- a/app/Filament/Resources/PushSettingResource.php
+++ b/app/Filament/Resources/PushSettingResource.php
@@ -7,14 +7,14 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\PushSettingResource\Pages\EditPushSetting;
 use App\Models\PushSetting;
 use Filament\Forms;
-use Filament\Resources\Form;
+use Filament\Forms\Form;
 use Filament\Resources\Resource;
 
 class PushSettingResource extends Resource
 {
     protected static ?string $model = PushSetting::class;
 
-    protected static ?string $navigationGroup = 'Settings';
+    protected static string|\UnitEnum|null $navigationGroup = 'Settings';
 
     public static function form(Form $form): Form
     {

--- a/app/Filament/Resources/SmtpSettingResource.php
+++ b/app/Filament/Resources/SmtpSettingResource.php
@@ -7,14 +7,14 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\SmtpSettingResource\Pages\EditSmtpSetting;
 use App\Models\SmtpSetting;
 use Filament\Forms;
-use Filament\Resources\Form;
+use Filament\Forms\Form;
 use Filament\Resources\Resource;
 
 class SmtpSettingResource extends Resource
 {
     protected static ?string $model = SmtpSetting::class;
 
-    protected static ?string $navigationGroup = 'Settings';
+    protected static string|\UnitEnum|null $navigationGroup = 'Settings';
 
     public static function form(Form $form): Form
     {

--- a/app/Filament/Resources/TemplateResource.php
+++ b/app/Filament/Resources/TemplateResource.php
@@ -9,10 +9,10 @@ use App\Filament\Resources\TemplateResource\Pages\EditTemplate;
 use App\Filament\Resources\TemplateResource\Pages\ListTemplates;
 use App\Models\Template;
 use Filament\Forms;
-use Filament\Resources\Form;
+use Filament\Forms\Form;
 use Filament\Resources\Resource;
-use Filament\Resources\Table;
 use Filament\Tables;
+use Filament\Tables\Table;
 
 class TemplateResource extends Resource
 {

--- a/app/Filament/Widgets/BounceComplaintChart.php
+++ b/app/Filament/Widgets/BounceComplaintChart.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Services\StatsService;
+use Filament\Widgets\LineChartWidget;
+
+class BounceComplaintChart extends LineChartWidget
+{
+    protected ?string $heading = 'Bounces & Complaints';
+
+    protected function getData(): array
+    {
+        $data = app(StatsService::class)->bouncesComplaintsTrend();
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Bounced',
+                    'data' => array_values($data['bounced']),
+                ],
+                [
+                    'label' => 'Complained',
+                    'data' => array_values($data['complained']),
+                ],
+            ],
+            'labels' => array_keys($data['bounced'] + $data['complained']),
+        ];
+    }
+}

--- a/app/Filament/Widgets/DeliveriesPerDayChart.php
+++ b/app/Filament/Widgets/DeliveriesPerDayChart.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Services\StatsService;
+use Filament\Widgets\LineChartWidget;
+
+class DeliveriesPerDayChart extends LineChartWidget
+{
+    protected ?string $heading = 'Deliveries per day';
+
+    protected function getData(): array
+    {
+        $data = app(StatsService::class)->deliveriesPerDay();
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Deliveries',
+                    'data' => array_values($data),
+                ],
+            ],
+            'labels' => array_keys($data),
+        ];
+    }
+}

--- a/app/Filament/Widgets/HorizonHealthWidget.php
+++ b/app/Filament/Widgets/HorizonHealthWidget.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Services\StatsService;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class HorizonHealthWidget extends BaseWidget
+{
+    protected function getStats(): array
+    {
+        $health = app(StatsService::class)->systemHealth();
+
+        return [
+            Stat::make('Queue', (string) $health['queue_size']),
+            Stat::make('Failed Jobs', (string) $health['failed_jobs']),
+            Stat::make('Horizon', (string) $health['horizon_status']),
+        ];
+    }
+}

--- a/app/Filament/Widgets/StatsOverview.php
+++ b/app/Filament/Widgets/StatsOverview.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Services\StatsService;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class StatsOverview extends BaseWidget
+{
+    protected function getStats(): array
+    {
+        $stats = app(StatsService::class)->totals();
+
+        return [
+            Stat::make('Contacts', (string) $stats['contacts']['total']),
+            Stat::make('Deliveries', (string) $stats['deliveries']['sent']),
+            Stat::make('Events', (string) $stats['events_ingested']),
+        ];
+    }
+}

--- a/app/Filament/Widgets/TopAutomationsChart.php
+++ b/app/Filament/Widgets/TopAutomationsChart.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Services\StatsService;
+use Filament\Widgets\BarChartWidget;
+
+class TopAutomationsChart extends BarChartWidget
+{
+    protected ?string $heading = 'Top Automations';
+
+    protected function getData(): array
+    {
+        $data = app(StatsService::class)->topAutomations();
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Sends',
+                    'data' => array_values($data),
+                ],
+            ],
+            'labels' => array_keys($data),
+        ];
+    }
+}

--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Services\StatsService;
+use Symfony\Component\HttpFoundation\Response;
+
+class StatsController extends Controller
+{
+    public function __invoke(StatsService $stats): Response
+    {
+        return response()->json([
+            'data' => $stats->totals(currentWorkspace()),
+        ]);
+    }
+}

--- a/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsAdmin
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->user()?->is_admin) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -27,6 +27,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'is_admin',
     ];
 
     /**
@@ -49,6 +50,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_admin' => 'boolean',
         ];
     }
 

--- a/app/Services/StatsService.php
+++ b/app/Services/StatsService.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\ContactStatus;
+use App\Enums\DeliveryStatus;
+use App\Models\Automation;
+use App\Models\Contact;
+use App\Models\Delivery;
+use App\Models\Event;
+use App\Models\Workspace;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Horizon\Horizon;
+
+class StatsService
+{
+    /**
+     * Get aggregate totals for the given workspace or globally.
+     *
+     * @return array<string, mixed>
+     */
+    public function totals(?Workspace $workspace = null): array
+    {
+        $contactQuery = Contact::query()->when($workspace, fn ($q) => $q->where('workspace_id', $workspace->id));
+        $deliveryQuery = Delivery::query()->when($workspace, fn ($q) => $q->where('workspace_id', $workspace->id));
+        $eventQuery = Event::query()->when($workspace, fn ($q) => $q->where('workspace_id', $workspace->id));
+
+        $totalContacts = $contactQuery->count();
+        $activeContacts = (clone $contactQuery)->where('status', ContactStatus::Active)->count();
+        $suppressedContacts = $totalContacts - $activeContacts;
+
+        $sentDeliveries = (clone $deliveryQuery)->whereIn('status', [
+            DeliveryStatus::Sent,
+            DeliveryStatus::Bounced,
+            DeliveryStatus::Complained,
+            DeliveryStatus::Failed,
+        ])->count();
+
+        $delivered = (clone $deliveryQuery)->where('status', DeliveryStatus::Sent)->count();
+        $bounced = (clone $deliveryQuery)->where('status', DeliveryStatus::Bounced)->count();
+        $complained = (clone $deliveryQuery)->where('status', DeliveryStatus::Complained)->count();
+        $failed = (clone $deliveryQuery)->where('status', DeliveryStatus::Failed)->count();
+
+        $opens = (clone $eventQuery)->where('name', 'open')->count();
+        $clicks = (clone $eventQuery)->where('name', 'click')->count();
+        $unsubscribes = (clone $contactQuery)->where('status', ContactStatus::Unsubscribed)->count();
+
+        $openRate = $sentDeliveries > 0 ? $opens / $sentDeliveries : 0.0;
+        $clickRate = $sentDeliveries > 0 ? $clicks / $sentDeliveries : 0.0;
+        $unsubscribeRate = $totalContacts > 0 ? $unsubscribes / $totalContacts : 0.0;
+
+        return [
+            'contacts' => [
+                'total' => $totalContacts,
+                'active' => $activeContacts,
+                'suppressed' => $suppressedContacts,
+            ],
+            'deliveries' => [
+                'sent' => $sentDeliveries,
+                'delivered' => $delivered,
+                'bounced' => $bounced,
+                'complained' => $complained,
+                'failed' => $failed,
+            ],
+            'rates' => [
+                'open' => $openRate,
+                'click' => $clickRate,
+                'unsubscribe' => $unsubscribeRate,
+            ],
+            'events_ingested' => $eventQuery->count(),
+            'automations_executed' => $deliveryQuery->count(),
+        ];
+    }
+
+    /**
+     * Deliveries per day for last 30 days.
+     *
+     * @return array<string, int>
+     */
+    public function deliveriesPerDay(?Workspace $workspace = null): array
+    {
+        $start = Carbon::now()->subDays(29)->startOfDay();
+
+        $query = Delivery::query()
+            ->when($workspace, fn ($q) => $q->where('workspace_id', $workspace->id))
+            ->whereNotNull('sent_at')
+            ->where('sent_at', '>=', $start)
+            ->selectRaw('date(sent_at) as day, count(*) as total')
+            ->groupBy('day')
+            ->orderBy('day');
+
+        return $query->pluck('total', 'day')->all();
+    }
+
+    /**
+     * Bounce and complaint trend grouped by day.
+     *
+     * @return array{bounced: array<string,int>, complained: array<string,int>}
+     */
+    public function bouncesComplaintsTrend(?Workspace $workspace = null): array
+    {
+        $start = Carbon::now()->subDays(29)->startOfDay();
+
+        $base = Delivery::query()
+            ->when($workspace, fn ($q) => $q->where('workspace_id', $workspace->id))
+            ->whereIn('status', [DeliveryStatus::Bounced, DeliveryStatus::Complained])
+            ->whereNotNull('sent_at')
+            ->where('sent_at', '>=', $start)
+            ->selectRaw('date(sent_at) as day, status, count(*) as total')
+            ->groupBy('day', 'status')
+            ->get();
+
+        $bounced = [];
+        $complained = [];
+
+        foreach ($base as $row) {
+            if ($row->status === DeliveryStatus::Bounced) {
+                $bounced[$row->day] = (int) $row->total;
+            }
+            if ($row->status === DeliveryStatus::Complained) {
+                $complained[$row->day] = (int) $row->total;
+            }
+        }
+
+        return [
+            'bounced' => $bounced,
+            'complained' => $complained,
+        ];
+    }
+
+    /**
+     * Top automations by send count.
+     *
+     * @return array<string,int>
+     */
+    public function topAutomations(?Workspace $workspace = null): array
+    {
+        $query = Delivery::query()
+            ->when($workspace, fn ($q) => $q->where('workspace_id', $workspace->id))
+            ->whereNotNull('automation_id')
+            ->selectRaw('automation_id, count(*) as total')
+            ->groupBy('automation_id')
+            ->orderByDesc('total')
+            ->limit(5)
+            ->with('automation:id,name');
+
+        $data = [];
+        foreach ($query->get() as $row) {
+            /** @var Delivery $row */
+            $name = $row->automation?->name ?? 'Unknown';
+            $data[$name] = (int) $row->total;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Basic system health indicators.
+     *
+     * @return array<string,mixed>
+     */
+    public function systemHealth(): array
+    {
+        return [
+            'queue_size' => Queue::size(),
+            'failed_jobs' => DB::table('failed_jobs')->count(),
+            'horizon_status' => Horizon::status(),
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Filament\AdminPanelProvider;
+use App\Http\Middleware\EnsureUserIsAdmin;
 use App\Http\Middleware\WorkspaceResolve;
 use Illuminate\Auth\Middleware\Authenticate;
 use Illuminate\Foundation\Application;
@@ -19,8 +21,12 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'auth' => Authenticate::class,
             'workspace' => WorkspaceResolve::class,
+            'admin' => EnsureUserIsAdmin::class,
         ]);
     })
+    ->withProviders([
+        AdminPanelProvider::class,
+    ])
     ->withExceptions(function (Exceptions $exceptions): void {
         //
     })->create();

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -31,6 +31,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'is_admin' => false,
         ];
     }
 
@@ -41,6 +42,13 @@ class UserFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
+        ]);
+    }
+
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_admin' => true,
         ]);
     }
 }

--- a/database/migrations/2025_09_06_095953_add_is_admin_to_users_table.php
+++ b/database/migrations/2025_09_06_095953_add_is_admin_to_users_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->boolean('is_admin')->default(false)->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\ContactController;
 use App\Http\Controllers\EventController;
 use App\Http\Controllers\DeviceTokenController;
 use App\Http\Controllers\SmtpSettingsController;
+use App\Http\Controllers\StatsController;
 use App\Http\Controllers\TemplateController;
 use Illuminate\Support\Facades\Route;
 
@@ -31,4 +32,6 @@ Route::middleware(['auth:sanctum', 'workspace'])->group(function (): void {
     Route::apiResource('templates', TemplateController::class);
     Route::post('/templates/{template}/preview', [TemplateController::class, 'preview']);
     Route::post('/templates/{template}/test', [TemplateController::class, 'test']);
+
+    Route::middleware('admin')->get('/admin/stats', StatsController::class);
 });

--- a/tests/Feature/AdminDashboardTest.php
+++ b/tests/Feature/AdminDashboardTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Models\Workspace;
+use App\Models\Contact;
+use App\Models\Delivery;
+use App\Enums\DeliveryStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\getJson;
+
+uses(RefreshDatabase::class);
+
+if (! function_exists('authHeaders')) {
+    function authHeaders(User $user, Workspace $workspace): array
+    {
+        $token = $user->createToken('api')->plainTextToken;
+
+        return [
+            'Authorization' => "Bearer {$token}",
+            'X-Workspace' => $workspace->slug,
+        ];
+    }
+}
+
+it('blocks non-admin users', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create([
+        'is_admin' => false,
+    ]);
+
+    $response = getJson('/api/admin/stats', authHeaders($user, $workspace));
+
+    $response->assertStatus(403);
+});
+
+it('returns stats for admin', function (): void {
+    $workspace = Workspace::factory()->create();
+    $admin = User::factory()->for($workspace)->create([
+        'is_admin' => true,
+    ]);
+
+    Contact::factory()->for($workspace)->count(3)->create();
+
+    Delivery::factory()->for($workspace)->state([
+        'status' => DeliveryStatus::Sent,
+        'sent_at' => now(),
+    ])->count(2)->create();
+
+    $response = getJson('/api/admin/stats', authHeaders($admin, $workspace));
+
+    $response->assertOk()
+        ->assertJsonPath('data.contacts.total', 3)
+        ->assertJsonPath('data.deliveries.sent', 2);
+});

--- a/tests/Unit/StatsServiceTest.php
+++ b/tests/Unit/StatsServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\DeliveryStatus;
+use App\Models\Contact;
+use App\Models\Delivery;
+use App\Models\Event;
+use App\Models\Workspace;
+use App\Services\StatsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+it('calculates totals from data', function (): void {
+    $workspace = Workspace::factory()->create();
+
+    Contact::factory()->for($workspace)->count(2)->create();
+    Contact::factory()->for($workspace)->create([
+        'status' => \App\Enums\ContactStatus::Unsubscribed,
+    ]);
+
+    Delivery::factory()->for($workspace)->state([
+        'status' => DeliveryStatus::Sent,
+        'sent_at' => now(),
+    ])->create();
+    Delivery::factory()->for($workspace)->state([
+        'status' => DeliveryStatus::Bounced,
+        'sent_at' => now(),
+    ])->create();
+
+    Event::factory()->for($workspace)->create([
+        'name' => 'open',
+    ]);
+    Event::factory()->for($workspace)->create([
+        'name' => 'click',
+    ]);
+
+    $stats = app(StatsService::class)->totals($workspace);
+
+    expect($stats['contacts']['total'])->toBe(3)
+        ->and($stats['contacts']['active'])->toBe(2)
+        ->and($stats['deliveries']['sent'])->toBe(2)
+        ->and($stats['deliveries']['bounced'])->toBe(1)
+        ->and($stats['rates']['open'])->toBeFloat()
+        ->and($stats['rates']['click'])->toBeFloat();
+});
+
+it('groups deliveries per day', function (): void {
+    $workspace = Workspace::factory()->create();
+
+    Delivery::factory()->for($workspace)->state([
+        'status' => DeliveryStatus::Sent,
+        'sent_at' => now()->subDay(),
+    ])->create();
+    Delivery::factory()->for($workspace)->state([
+        'status' => DeliveryStatus::Sent,
+        'sent_at' => now(),
+    ])->count(2)->create();
+
+    $data = app(StatsService::class)->deliveriesPerDay($workspace);
+
+    expect($data)->toHaveCount(2)
+        ->and($data[now()->subDay()->format('Y-m-d')])->toBe(1)
+        ->and($data[now()->format('Y-m-d')])->toBe(2);
+});


### PR DESCRIPTION
## Summary
- secure admin routes behind new `EnsureUserIsAdmin` middleware
- provide stats endpoints and service for contacts, deliveries, and events
- scaffold Filament admin panel with dashboard widgets and Horizon health

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2cd766e0832b9e6e100fb162ba20