### PR TITLE
Add auth flow tracing and tighten admin panel check

### DIFF
--- a/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -6,15 +6,28 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 
 class EnsureUserIsAdmin
 {
     public function handle(Request $request, Closure $next): Response
     {
-        if (! $request->user()?->is_admin) {
-            abort(403);
+        $user = $request->user();
+
+        if (! $user?->is_admin) {
+            Log::warning('Non-admin user blocked from admin panel', [
+                'user_id' => $user?->id,
+                'email' => $user?->email,
+            ]);
+
+            abort(403, 'Only administrators may access the admin panel.');
         }
+
+        Log::info('Admin access granted', [
+            'user_id' => $user->id,
+            'email' => $user->email,
+        ]);
 
         return $next($request);
     }

--- a/app/Providers/AuthDebugServiceProvider.php
+++ b/app/Providers/AuthDebugServiceProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use Illuminate\Auth\Events\Attempting;
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Logout;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\ServiceProvider;
+
+class AuthDebugServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Event::listen(Attempting::class, function (Attempting $event): void {
+            Log::info('Auth attempt', [
+                'guard' => $event->guard,
+                'credentials' => Arr::except($event->credentials, ['password']),
+            ]);
+        });
+
+        Event::listen(Failed::class, function (Failed $event): void {
+            Log::warning('Auth failed', [
+                'guard' => $event->guard,
+                'user_id' => $event->user?->id,
+                'credentials' => Arr::except($event->credentials, ['password']),
+            ]);
+        });
+
+        Event::listen(Login::class, function (Login $event): void {
+            Log::info('Auth success', [
+                'guard' => $event->guard,
+                'user_id' => $event->user->id,
+                'is_admin' => $event->user->is_admin,
+            ]);
+        });
+
+        Event::listen(Logout::class, function (Logout $event): void {
+            Log::info('Auth logout', [
+                'guard' => $event->guard,
+                'user_id' => $event->user?->id,
+            ]);
+        });
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -26,6 +26,7 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withProviders([
         AdminPanelProvider::class,
+        \App\Providers\AuthDebugServiceProvider::class,
     ])
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/tests/Feature/AdminPanelAccessTest.php
+++ b/tests/Feature/AdminPanelAccessTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+uses(RefreshDatabase::class);
+
+it('blocks non-admin users from panel', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create([
+        'is_admin' => false,
+    ]);
+
+    actingAs($user);
+
+    $response = get('/admin');
+
+    $response->assertStatus(403);
+});
+
+it('allows admin users into panel', function (): void {
+    $workspace = Workspace::factory()->create();
+    $admin = User::factory()->for($workspace)->create([
+        'is_admin' => true,
+    ]);
+
+    actingAs($admin);
+
+    $response = get('/admin');
+
+    $response->assertOk();
+});


### PR DESCRIPTION
## Summary
- log auth lifecycle events for debugging
- record non-admin access attempts and provide clearer 403 response
- cover admin panel access with tests

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68bc3c9520c0832bb1869dcdf357fbe8