### PR TITLE
feat: version API and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To send pushes:
 1. Configure push settings for your workspace (Expo or OneSignal) via the Filament admin panel.
 2. Register device tokens for contacts:
    ```bash
-   curl -X POST http://localhost/api/contacts/{contact_id}/device-tokens \
+   curl -X POST http://localhost/api/v1/contacts/{contact_id}/device-tokens \
      -H "Authorization: Bearer <token>" \
      -H "X-Workspace: demo" \
      -H "Content-Type: application/json" \
@@ -78,7 +78,7 @@ php artisan make:demo
 ```
 The command prints an API token and example requests:
 ```bash
-curl -X POST http://localhost/api/events \
+curl -X POST http://localhost/api/v1/events \
   -H "Authorization: Bearer <token>" \
   -H "X-Workspace: demo" \
   -H "Content-Type: application/json" \

--- a/app/Console/Commands/MakeDemo.php
+++ b/app/Console/Commands/MakeDemo.php
@@ -84,7 +84,7 @@ class MakeDemo extends Command
         $this->line("API token: {$token}");
         $this->line('');
         $this->line('Example curl to trigger event:');
-        $this->line('curl -X POST http://localhost/api/events \\');
+        $this->line('curl -X POST http://localhost/api/v1/events \\');
         $this->line("  -H \"Authorization: Bearer {$token}\" \\");
         $this->line('  -H "X-Workspace: demo" \\');
         $this->line('  -H "Content-Type: application/json" \\');

--- a/app/Http/Controllers/Api/V1/AuthTokenController.php
+++ b/app/Http/Controllers/Api/V1/AuthTokenController.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
 
 use App\Models\User;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Api/V1/ContactController.php
+++ b/app/Http/Controllers/Api/V1/ContactController.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
 
 use App\Models\Contact;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Api/V1/DeviceTokenController.php
+++ b/app/Http/Controllers/Api/V1/DeviceTokenController.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
 
 use App\Models\Contact;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Api/V1/EventController.php
+++ b/app/Http/Controllers/Api/V1/EventController.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
 
 use App\Jobs\ProcessEvent;
 use App\Models\Contact;

--- a/app/Http/Controllers/Api/V1/SmtpSettingsController.php
+++ b/app/Http/Controllers/Api/V1/SmtpSettingsController.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
 
 use App\Mail\TestSmtpMail;
 use App\Models\SmtpSetting;

--- a/app/Http/Controllers/Api/V1/StatsController.php
+++ b/app/Http/Controllers/Api/V1/StatsController.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
 
 use App\Services\StatsService;
 use Symfony\Component\HttpFoundation\Response;

--- a/app/Http/Controllers/Api/V1/TemplateController.php
+++ b/app/Http/Controllers/Api/V1/TemplateController.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
 
 use App\Mail\TemplateTestMail;
 use App\Models\Contact;

--- a/docs/api/auth/README.md
+++ b/docs/api/auth/README.md
@@ -1,0 +1,23 @@
+# Authentication
+
+## POST /api/v1/auth/token
+Issue an access token for authenticated API requests.
+
+### Request
+```json
+{
+  "email": "user@example.com",
+  "password": "secret"
+}
+```
+
+### Response
+```json
+{
+  "data": {
+    "token": "string"
+  }
+}
+```
+
+Returns `401` with an error object when credentials are invalid.

--- a/docs/api/contacts/README.md
+++ b/docs/api/contacts/README.md
@@ -1,0 +1,74 @@
+# Contacts
+
+## POST /api/v1/contacts
+Create or update a contact in the current workspace.
+
+### Request
+```json
+{
+  "email": "user@example.com",
+  "first_name": "Jane",
+  "last_name": "Doe",
+  "attributes": {
+    "plan": "pro"
+  }
+}
+```
+
+### Response
+```json
+{
+  "data": {
+    "id": 1,
+    "email": "user@example.com",
+    "first_name": "Jane",
+    "last_name": "Doe",
+    "attributes": {
+      "plan": "pro"
+    }
+  }
+}
+```
+
+## POST /api/v1/contacts/import
+Bulk import contacts from JSON or CSV payloads.
+
+### Request
+```json
+[
+  {"email": "a@example.com"},
+  {"email": "b@example.com", "first_name": "B"}
+]
+```
+
+### Response
+```json
+{
+  "data": {
+    "created": 2,
+    "updated": 0,
+    "errors": []
+  }
+}
+```
+
+## POST /api/v1/contacts/{id}/device-tokens
+Attach a device token to a contact for push notifications.
+
+### Request
+```json
+{
+  "token": "ExponentPushToken[xxxxxxxx]",
+  "platform": "ios",
+  "driver": "expo"
+}
+```
+
+### Response
+```json
+{
+  "data": {
+    "token": "ExponentPushToken[xxxxxxxx]"
+  }
+}
+```

--- a/docs/api/events/README.md
+++ b/docs/api/events/README.md
@@ -1,0 +1,25 @@
+# Events
+
+## POST /api/v1/events
+Ingest a custom event that can trigger automations.
+
+### Request
+```json
+{
+  "name": "user.signed_up",
+  "contact_email": "user@example.com",
+  "payload": {
+    "plan": "pro"
+  },
+  "auto_create_contact": true
+}
+```
+
+### Response
+```json
+{
+  "data": {
+    "id": 1
+  }
+}
+```

--- a/docs/api/health/README.md
+++ b/docs/api/health/README.md
@@ -1,0 +1,13 @@
+# Health
+
+## GET /api/v1/ping
+Simple health check to verify the API is reachable.
+
+### Response
+```json
+{
+  "data": {
+    "pong": true
+  }
+}
+```

--- a/docs/api/smtp-settings/README.md
+++ b/docs/api/smtp-settings/README.md
@@ -1,0 +1,76 @@
+# SMTP Settings
+
+## GET /api/v1/smtp-settings
+Retrieve the current SMTP configuration for the workspace.
+
+### Response
+```json
+{
+  "data": {
+    "id": 1,
+    "host": "smtp.example.com",
+    "port": 587,
+    "username": "user",
+    "password": "********",
+    "encryption": "tls",
+    "from_name": "Example",
+    "from_email": "no-reply@example.com",
+    "reply_to": null,
+    "is_active": true
+  }
+}
+```
+
+## POST /api/v1/smtp-settings
+Create or update SMTP credentials.
+
+### Request
+```json
+{
+  "host": "smtp.example.com",
+  "port": 587,
+  "username": "user",
+  "password": "secret",
+  "encryption": "tls",
+  "from_name": "Example",
+  "from_email": "no-reply@example.com",
+  "reply_to": "support@example.com"
+}
+```
+
+### Response
+```json
+{
+  "data": {
+    "id": 1,
+    "host": "smtp.example.com",
+    "port": 587,
+    "username": "user",
+    "password": "********",
+    "encryption": "tls",
+    "from_name": "Example",
+    "from_email": "no-reply@example.com",
+    "reply_to": "support@example.com",
+    "is_active": true
+  }
+}
+```
+
+## POST /api/v1/smtp-settings/test
+Send a test email using the stored SMTP settings.
+
+### Request
+```json
+{
+  "to": "user@example.com"
+}
+```
+
+### Response
+```json
+{
+  "data": {
+    "sent": true
+  }
+}
+```

--- a/docs/api/stats/README.md
+++ b/docs/api/stats/README.md
@@ -1,0 +1,15 @@
+# Admin Stats
+
+## GET /api/v1/admin/stats
+Retrieve aggregated statistics for the workspace. Requires admin privileges.
+
+### Response
+```json
+{
+  "data": {
+    "contacts": 10,
+    "events": 25,
+    "templates": 3
+  }
+}
+```

--- a/docs/api/templates/README.md
+++ b/docs/api/templates/README.md
@@ -1,0 +1,100 @@
+# Templates
+
+## GET /api/v1/templates
+List all templates in the workspace.
+
+### Response
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "Welcome",
+      "subject": "Welcome!",
+      "html": "<p>Hello {{contact.first_name}}</p>",
+      "text": "Hello",
+      "editor_meta": {}
+    }
+  ]
+}
+```
+
+## POST /api/v1/templates
+Create a new template.
+
+### Request
+```json
+{
+  "name": "Welcome",
+  "subject": "Welcome!",
+  "html": "<p>Hello {{contact.first_name}}</p>",
+  "text": "Hello",
+  "editor_meta": {}
+}
+```
+
+### Response
+```json
+{
+  "data": {
+    "id": 1,
+    "name": "Welcome",
+    "subject": "Welcome!",
+    "html": "<p>Hello {{contact.first_name}}</p>",
+    "text": "Hello",
+    "editor_meta": {}
+  }
+}
+```
+
+## GET /api/v1/templates/{id}
+Retrieve a single template.
+
+## PUT /api/v1/templates/{id}
+Update template attributes (same fields as create).
+
+## DELETE /api/v1/templates/{id}
+Remove a template. Responds with `204 No Content` on success.
+
+## POST /api/v1/templates/{id}/preview
+Render a template with optional contact or event context.
+
+### Request
+```json
+{
+  "contact_id": 1,
+  "event_id": 2
+}
+```
+
+### Response
+```json
+{
+  "data": {
+    "subject": "Welcome!",
+    "html": "<p>Hello Jane</p>",
+    "text": "Hello Jane"
+  }
+}
+```
+
+## POST /api/v1/templates/{id}/test
+Queue a test email using the template.
+
+### Request
+```json
+{
+  "to": "user@example.com",
+  "contact_id": 1,
+  "event_id": 2
+}
+```
+
+### Response
+```json
+{
+  "data": {
+    "sent": true
+  }
+}
+```

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,36 +2,9 @@
 
 declare(strict_types=1);
 
-use App\Http\Controllers\AuthTokenController;
-use App\Http\Controllers\ContactController;
-use App\Http\Controllers\EventController;
-use App\Http\Controllers\DeviceTokenController;
-use App\Http\Controllers\SmtpSettingsController;
-use App\Http\Controllers\StatsController;
-use App\Http\Controllers\TemplateController;
 use Illuminate\Support\Facades\Route;
 
-Route::post('/auth/token', AuthTokenController::class)->middleware('workspace');
-
-Route::middleware(['auth:sanctum', 'workspace'])->group(function (): void {
-    Route::get('/ping', function () {
-        return response()->json(['data' => ['pong' => true]]);
-    });
-
-    Route::get('/smtp-settings', [SmtpSettingsController::class, 'show']);
-    Route::post('/smtp-settings', [SmtpSettingsController::class, 'store']);
-    Route::post('/smtp-settings/test', [SmtpSettingsController::class, 'test']);
-
-    Route::post('/contacts', [ContactController::class, 'upsert']);
-    Route::post('/contacts/import', [ContactController::class, 'bulkImport']);
-
-    Route::post('/contacts/{contact}/device-tokens', [DeviceTokenController::class, 'store']);
-
-    Route::post('/events', [EventController::class, 'ingest']);
-
-    Route::apiResource('templates', TemplateController::class);
-    Route::post('/templates/{template}/preview', [TemplateController::class, 'preview']);
-    Route::post('/templates/{template}/test', [TemplateController::class, 'test']);
-
-    Route::middleware('admin')->get('/admin/stats', StatsController::class);
+Route::prefix('v1')->group(function (): void {
+    require __DIR__.'/api/v1.php';
 });
+

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Api\V1\AuthTokenController;
+use App\Http\Controllers\Api\V1\ContactController;
+use App\Http\Controllers\Api\V1\EventController;
+use App\Http\Controllers\Api\V1\DeviceTokenController;
+use App\Http\Controllers\Api\V1\SmtpSettingsController;
+use App\Http\Controllers\Api\V1\StatsController;
+use App\Http\Controllers\Api\V1\TemplateController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/auth/token', AuthTokenController::class)->middleware('workspace');
+
+Route::middleware(['auth:sanctum', 'workspace'])->group(function (): void {
+    Route::get('/ping', function () {
+        return response()->json(['data' => ['pong' => true]]);
+    });
+
+    Route::get('/smtp-settings', [SmtpSettingsController::class, 'show']);
+    Route::post('/smtp-settings', [SmtpSettingsController::class, 'store']);
+    Route::post('/smtp-settings/test', [SmtpSettingsController::class, 'test']);
+
+    Route::post('/contacts', [ContactController::class, 'upsert']);
+    Route::post('/contacts/import', [ContactController::class, 'bulkImport']);
+
+    Route::post('/contacts/{contact}/device-tokens', [DeviceTokenController::class, 'store']);
+
+    Route::post('/events', [EventController::class, 'ingest']);
+
+    Route::apiResource('templates', TemplateController::class);
+    Route::post('/templates/{template}/preview', [TemplateController::class, 'preview']);
+    Route::post('/templates/{template}/test', [TemplateController::class, 'test']);
+
+    Route::middleware('admin')->get('/admin/stats', StatsController::class);
+});

--- a/tests/Feature/AdminDashboardTest.php
+++ b/tests/Feature/AdminDashboardTest.php
@@ -31,7 +31,7 @@ it('blocks non-admin users', function (): void {
         'is_admin' => false,
     ]);
 
-    $response = getJson('/api/admin/stats', authHeaders($user, $workspace));
+    $response = getJson('/api/v1/admin/stats', authHeaders($user, $workspace));
 
     $response->assertStatus(403);
 });
@@ -49,7 +49,7 @@ it('returns stats for admin', function (): void {
         'sent_at' => now(),
     ])->count(2)->create();
 
-    $response = getJson('/api/admin/stats', authHeaders($admin, $workspace));
+    $response = getJson('/api/v1/admin/stats', authHeaders($admin, $workspace));
 
     $response->assertOk()
         ->assertJsonPath('data.contacts.total', 3)

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -15,7 +15,7 @@ it('can request token with email/password', function (): void {
         'password' => bcrypt('secret'),
     ]);
 
-    $response = postJson('/api/auth/token', [
+    $response = postJson('/api/v1/auth/token', [
         'email' => $user->email,
         'password' => 'secret',
     ], ['X-Workspace' => $workspace->slug]);

--- a/tests/Feature/ContactsApiTest.php
+++ b/tests/Feature/ContactsApiTest.php
@@ -27,7 +27,7 @@ it('upsert creates contact', function (): void {
     $workspace = Workspace::factory()->create();
     $user = User::factory()->for($workspace)->create();
 
-    $response = postJson('/api/contacts', [
+    $response = postJson('/api/v1/contacts', [
         'email' => 'jane@example.com',
         'first_name' => 'Jane',
     ], authHeaders($user, $workspace));
@@ -42,12 +42,12 @@ it('upsert updates existing contact on second call', function (): void {
     $workspace = Workspace::factory()->create();
     $user = User::factory()->for($workspace)->create();
 
-    postJson('/api/contacts', [
+    postJson('/api/v1/contacts', [
         'email' => 'jane@example.com',
         'first_name' => 'Jane',
     ], authHeaders($user, $workspace));
 
-    $response = postJson('/api/contacts', [
+    $response = postJson('/api/v1/contacts', [
         'email' => 'jane@example.com',
         'first_name' => 'Janet',
     ], authHeaders($user, $workspace));
@@ -69,7 +69,7 @@ it('bulk import returns counts', function (): void {
         ['email' => 'john@example.com', 'first_name' => 'John'],
     ];
 
-    $response = postJson('/api/contacts/import', $payload, authHeaders($user, $workspace));
+    $response = postJson('/api/v1/contacts/import', $payload, authHeaders($user, $workspace));
 
     $response->assertOk()
         ->assertJsonPath('data.created', 1)

--- a/tests/Feature/EventsIngestionTest.php
+++ b/tests/Feature/EventsIngestionTest.php
@@ -32,7 +32,7 @@ it('stores event, links contact, and dispatches job', function (): void {
     $workspace = Workspace::factory()->create();
     $user = User::factory()->for($workspace)->create();
 
-    $response = postJson('/api/events', [
+    $response = postJson('/api/v1/events', [
         'name' => 'user.signed_up',
         'contact_email' => 'jane@example.com',
         'payload' => ['plan' => 'pro'],

--- a/tests/Feature/SendPushNotificationTest.php
+++ b/tests/Feature/SendPushNotificationTest.php
@@ -62,7 +62,7 @@ it('sends push notification when event ingested', function (): void {
         ],
     ]);
 
-    postJson('/api/events', [
+    postJson('/api/v1/events', [
         'name' => 'signup',
         'contact_email' => $contact->email,
     ], authHeaders($user, $workspace))->assertCreated();

--- a/tests/Feature/SmtpSettingsTest.php
+++ b/tests/Feature/SmtpSettingsTest.php
@@ -30,7 +30,7 @@ it('stores settings encrypting password', function (): void {
     $workspace = Workspace::factory()->create();
     $user = User::factory()->for($workspace)->create();
 
-    $response = postJson('/api/smtp-settings', [
+    $response = postJson('/api/v1/smtp-settings', [
         'host' => 'smtp.example.com',
         'port' => 587,
         'username' => 'jane',
@@ -55,7 +55,7 @@ it('shows masked password on fetch', function (): void {
         'password_encrypted' => encrypt('super-secret'),
     ]);
 
-    $response = getJson('/api/smtp-settings', authHeaders($user, $workspace));
+    $response = getJson('/api/v1/smtp-settings', authHeaders($user, $workspace));
 
     $response->assertOk()
         ->assertJsonPath('data.password', '********');
@@ -70,7 +70,7 @@ it('can test smtp settings sending mail', function (): void {
         'password_encrypted' => encrypt('secret'),
     ]);
 
-    $response = postJson('/api/smtp-settings/test', [
+    $response = postJson('/api/v1/smtp-settings/test', [
         'to' => 'test@example.com',
     ], authHeaders($user, $workspace));
 

--- a/tests/Feature/TemplatesTest.php
+++ b/tests/Feature/TemplatesTest.php
@@ -33,7 +33,7 @@ it('crud works', function (): void {
     $workspace = Workspace::factory()->create();
     $user = User::factory()->for($workspace)->create();
 
-    $response = postJson('/api/templates', [
+    $response = postJson('/api/v1/templates', [
         'name' => 'Welcome',
         'subject' => 'Hello {{ $contact->first_name }}',
         'html' => '<p>Hi {{ $contact->first_name }}</p>',
@@ -45,14 +45,14 @@ it('crud works', function (): void {
 
     $id = $response->json('data.id');
 
-    $response = putJson("/api/templates/{$id}", [
+    $response = putJson("/api/v1/templates/{$id}", [
         'name' => 'Updated',
     ], authHeaders($user, $workspace));
 
     $response->assertOk()
         ->assertJsonPath('data.name', 'Updated');
 
-    $response = deleteJson("/api/templates/{$id}", [], authHeaders($user, $workspace));
+    $response = deleteJson("/api/v1/templates/{$id}", [], authHeaders($user, $workspace));
     $response->assertNoContent();
 
     expect(Template::count())->toBe(0);
@@ -71,7 +71,7 @@ it('preview substitutes variables', function (): void {
         'text' => 'Dear {{ $contact->first_name }}',
     ]);
 
-    $response = postJson("/api/templates/{$template->id}/preview", [
+    $response = postJson("/api/v1/templates/{$template->id}/preview", [
         'contact_id' => $contact->id,
         'event_id' => $event->id,
     ], authHeaders($user, $workspace));
@@ -95,7 +95,7 @@ it('test send enqueues mail', function (): void {
         'text' => 'Hello {{ $contact->first_name }}',
     ]);
 
-    $response = postJson("/api/templates/{$template->id}/test", [
+    $response = postJson("/api/v1/templates/{$template->id}/test", [
         'to' => 'test@example.com',
         'contact_id' => $contact->id,
         'event_id' => $event->id,

--- a/tests/Feature/WorkspaceScopeTest.php
+++ b/tests/Feature/WorkspaceScopeTest.php
@@ -14,18 +14,18 @@ it('requires token and workspace header', function (): void {
     $user = User::factory()->for($workspace)->create();
     $token = $user->createToken('api')->plainTextToken;
 
-    getJson('/api/ping')->assertUnauthorized();
+    getJson('/api/v1/ping')->assertUnauthorized();
 
-    getJson('/api/ping', ['Authorization' => 'Bearer '.$token])
+    getJson('/api/v1/ping', ['Authorization' => 'Bearer '.$token])
         ->assertStatus(400);
 
     $this->flushHeaders();
     auth()->forgetGuards();
 
-    getJson('/api/ping', ['X-Workspace' => $workspace->slug])
+    getJson('/api/v1/ping', ['X-Workspace' => $workspace->slug])
         ->assertUnauthorized();
 
-    getJson('/api/ping', [
+    getJson('/api/v1/ping', [
         'Authorization' => 'Bearer '.$token,
         'X-Workspace' => $workspace->slug,
     ])->assertOk();


### PR DESCRIPTION
## Summary
- version all API controllers and routes under `/api/v1`
- document authentication, contacts, events, templates, SMTP settings, stats and health endpoints

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68bc427f63ac832bbaf8f76d58be40b1