### PR TITLE
test: ensure admin can login and access panel

### DIFF
--- a/tests/Feature/AdminPanelAccessTest.php
+++ b/tests/Feature/AdminPanelAccessTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Models\Workspace;
+use Filament\Auth\Pages\Login as FilamentLogin;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+use function Pest\Laravel\get;
+
+uses(RefreshDatabase::class);
+
+it('redirects guests to login', function (): void {
+    get('/admin')->assertRedirect('/admin/login');
+});
+
+it('allows admin to login and access panel', function (): void {
+    $workspace = Workspace::factory()->create();
+    $admin = User::factory()->for($workspace)->admin()->create();
+
+    Livewire::test(FilamentLogin::class)
+        ->fillForm([
+            'email' => $admin->email,
+            'password' => 'password',
+        ])
+        ->call('authenticate')
+        ->assertHasNoErrors()
+        ->assertRedirect('/admin');
+
+    get('/admin')->assertOk();
+});
+
+it('blocks non-admin users', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+
+    Livewire::test(FilamentLogin::class)
+        ->fillForm([
+            'email' => $user->email,
+            'password' => 'password',
+        ])
+        ->call('authenticate')
+        ->assertHasNoErrors()
+        ->assertRedirect('/admin');
+
+    get('/admin')->assertStatus(403);
+});
+


### PR DESCRIPTION
## Summary
- add feature tests covering admin panel authentication

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68bc91d406d8832b9ca37cf1f6fec863