### PR TITLE
Add device token deletion endpoint

### DIFF
--- a/app/Http/Controllers/Api/V1/DeviceTokenController.php
+++ b/app/Http/Controllers/Api/V1/DeviceTokenController.php
@@ -27,5 +27,12 @@ class DeviceTokenController extends Controller
 
         return response()->json(['data' => ['token' => $data['token']]], 201);
     }
+
+    public function destroy(Contact $contact, string $token): Response
+    {
+        $contact->deviceTokens()->where('token', $token)->firstOrFail()->delete();
+
+        return response()->noContent();
+    }
 }
 

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -26,6 +26,7 @@ Route::middleware(['auth:sanctum', 'workspace'])->group(function (): void {
     Route::post('/contacts/import', [ContactController::class, 'bulkImport']);
 
     Route::post('/contacts/{contact}/device-tokens', [DeviceTokenController::class, 'store']);
+    Route::delete('/contacts/{contact}/device-tokens/{token}', [DeviceTokenController::class, 'destroy']);
 
     Route::post('/events', [EventController::class, 'ingest']);
 

--- a/tests/Feature/DeviceTokensTest.php
+++ b/tests/Feature/DeviceTokensTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Contact;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\deleteJson;
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+if (!function_exists('authHeaders')) {
+    function authHeaders(User $user, Workspace $workspace): array
+    {
+        $token = $user->createToken('api')->plainTextToken;
+
+        return [
+            'Authorization' => "Bearer {$token}",
+            'X-Workspace' => $workspace->slug,
+        ];
+    }
+}
+
+it('removes device token from contact', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+    $contact = Contact::factory()->for($workspace)->create();
+
+    postJson("/api/v1/contacts/{$contact->id}/device-tokens", [
+        'token' => 'abc',
+        'platform' => 'ios',
+        'driver' => 'expo',
+    ], authHeaders($user, $workspace))->assertCreated();
+
+    deleteJson("/api/v1/contacts/{$contact->id}/device-tokens/abc", [], authHeaders($user, $workspace))
+        ->assertNoContent();
+
+    expect($contact->deviceTokens()->count())->toBe(0);
+});
+
+it('returns 404 for missing device token', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+    $contact = Contact::factory()->for($workspace)->create();
+
+    deleteJson("/api/v1/contacts/{$contact->id}/device-tokens/missing", [], authHeaders($user, $workspace))
+        ->assertNotFound();
+});
+


### PR DESCRIPTION
## Summary
- allow removing device tokens from contacts
- add DELETE `/contacts/{contact}/device-tokens/{token}` route
- cover device token removal and missing token behavior with tests

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68bca1878288832b885c2440e90f0966