### PR TITLE
Add full CRUD API for contacts

### DIFF
--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 use App\Http\Controllers\Api\V1\AuthTokenController;
 use App\Http\Controllers\Api\V1\ContactController;
-use App\Http\Controllers\Api\V1\EventController;
 use App\Http\Controllers\Api\V1\DeviceTokenController;
+use App\Http\Controllers\Api\V1\EventController;
 use App\Http\Controllers\Api\V1\SmtpSettingsController;
 use App\Http\Controllers\Api\V1\StatsController;
 use App\Http\Controllers\Api\V1\TemplateController;
@@ -22,9 +22,8 @@ Route::middleware(['auth:sanctum', 'workspace'])->group(function (): void {
     Route::post('/smtp-settings', [SmtpSettingsController::class, 'store']);
     Route::post('/smtp-settings/test', [SmtpSettingsController::class, 'test']);
 
-    Route::post('/contacts', [ContactController::class, 'upsert']);
     Route::post('/contacts/import', [ContactController::class, 'bulkImport']);
-
+    Route::apiResource('contacts', ContactController::class);
     Route::post('/contacts/{contact}/device-tokens', [DeviceTokenController::class, 'store']);
 
     Route::post('/events', [EventController::class, 'ingest']);

--- a/tests/Feature/ContactsApiTest.php
+++ b/tests/Feature/ContactsApiTest.php
@@ -7,11 +7,14 @@ use App\Models\User;
 use App\Models\Workspace;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
+use function Pest\Laravel\deleteJson;
+use function Pest\Laravel\getJson;
+use function Pest\Laravel\patchJson;
 use function Pest\Laravel\postJson;
 
 uses(RefreshDatabase::class);
 
-if (!function_exists('authHeaders')) {
+if (! function_exists('authHeaders')) {
     function authHeaders(User $user, Workspace $workspace): array
     {
         $token = $user->createToken('api')->plainTextToken;
@@ -78,4 +81,49 @@ it('bulk import returns counts', function (): void {
 
     expect(Contact::where('workspace_id', $workspace->id)->count())->toBe(2)
         ->and(Contact::where('email', 'jane@example.com')->first()->first_name)->toBe('Janet');
+});
+
+it('lists contacts', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+    Contact::factory()->for($workspace)->create(['email' => 'jane@example.com']);
+    Contact::factory()->for($workspace)->create(['email' => 'john@example.com']);
+
+    $response = getJson('/api/v1/contacts', authHeaders($user, $workspace));
+
+    $response->assertOk()->assertJsonCount(2, 'data');
+});
+
+it('shows a contact', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+    $contact = Contact::factory()->for($workspace)->create(['email' => 'jane@example.com']);
+
+    $response = getJson("/api/v1/contacts/{$contact->id}", authHeaders($user, $workspace));
+
+    $response->assertOk()->assertJsonPath('data.email', 'jane@example.com');
+});
+
+it('updates a contact', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+    $contact = Contact::factory()->for($workspace)->create(['email' => 'jane@example.com', 'first_name' => 'Jane']);
+
+    $response = patchJson("/api/v1/contacts/{$contact->id}", [
+        'first_name' => 'Janet',
+    ], authHeaders($user, $workspace));
+
+    $response->assertOk()->assertJsonPath('data.first_name', 'Janet');
+    expect($contact->refresh()->first_name)->toBe('Janet');
+});
+
+it('deletes a contact', function (): void {
+    $workspace = Workspace::factory()->create();
+    $user = User::factory()->for($workspace)->create();
+    $contact = Contact::factory()->for($workspace)->create(['email' => 'jane@example.com']);
+
+    $response = deleteJson("/api/v1/contacts/{$contact->id}", [], authHeaders($user, $workspace));
+
+    $response->assertNoContent();
+    expect(Contact::where('workspace_id', $workspace->id)->count())->toBe(0);
 });


### PR DESCRIPTION
## Summary
- implement index, show, update and destroy methods for contacts API
- expose contact endpoints via `Route::apiResource` with import endpoint
- test listing, retrieving, updating and deleting contacts

## Testing
- `php artisan test tests/Feature/ContactsApiTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68bca197256c832b922c48a962b9d0c8