### PR TITLE
Enable workspace switching in Filament panel

### DIFF
--- a/app/Filament/AdminPanelProvider.php
+++ b/app/Filament/AdminPanelProvider.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Filament;
 
 use App\Http\Middleware\EnsureUserIsAdmin;
+use App\Models\Workspace;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -16,6 +19,7 @@ use Filament\Support\Colors\Color;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
@@ -33,7 +37,8 @@ class AdminPanelProvider extends PanelProvider
                 'primary' => Color::Indigo,
             ])
             ->middleware([
-                'web'
+                'web',
+                'workspace',
                 // EncryptCookies::class,
                 // AddQueuedCookiesToResponse::class,
                 // StartSession::class,
@@ -48,7 +53,25 @@ class AdminPanelProvider extends PanelProvider
                 Authenticate::class,
                 EnsureUserIsAdmin::class,
             ])
-            ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
+            ->userMenuItems([
+                Action::make('workspace')
+                    ->label(fn (): string => currentWorkspace()?->name ?? 'Workspace')
+                    ->icon('heroicon-m-rectangle-stack')
+                    ->form([
+                        Select::make('workspace')
+                            ->label('Workspace')
+                            ->options(fn () => auth()->user()?->account->workspaces->pluck('name', 'slug')->toArray())
+                            ->default(fn (): ?string => session('workspace')),
+                    ])
+                    ->action(function (array $data, Request $request): void {
+                        $workspace = Workspace::where('slug', $data['workspace'])->first();
+                        if ($workspace !== null && $workspace->account_id === $request->user()->account_id) {
+                            $request->session()->put('workspace', $workspace->slug);
+                        }
+                    }),
+            ])
+            ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
+            ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->pages([
                 Pages\Dashboard::class,
             ]);

--- a/app/Http/Middleware/WorkspaceResolve.php
+++ b/app/Http/Middleware/WorkspaceResolve.php
@@ -13,7 +13,15 @@ class WorkspaceResolve
 {
     public function handle(Request $request, Closure $next): Response
     {
-        $slug = $request->header('X-Workspace');
+        $slug = $request->header('X-Workspace')
+            ?? ($request->hasSession() ? $request->session()->get('workspace') : null);
+
+        if ($slug === null && ($user = $request->user()) !== null && $request->hasSession()) {
+            $slug = $user->workspace()->value('slug');
+            if ($slug !== null) {
+                $request->session()->put('workspace', $slug);
+            }
+        }
 
         if ($slug === null) {
             return response()->json([

--- a/tests/Feature/WorkspaceSwitchTest.php
+++ b/tests/Feature/WorkspaceSwitchTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Account;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+uses(RefreshDatabase::class);
+
+it('defaults workspace and allows switching', function (): void {
+    $account = Account::factory()->create();
+    $workspaceOne = Workspace::factory()->for($account)->create(['slug' => 'one']);
+    $workspaceTwo = Workspace::factory()->for($account)->create(['slug' => 'two']);
+    $admin = User::factory()->for($account)->for($workspaceOne)->admin()->create();
+
+    actingAs($admin);
+
+    get('/admin')->assertOk()->assertSessionHas('workspace', 'one');
+
+    session(['workspace' => 'two']);
+
+    get('/admin')->assertOk()->assertSessionHas('workspace', 'two');
+});


### PR DESCRIPTION
## Summary
- Resolve workspaces from session and default to user's workspace
- Add workspace selection action and middleware to Filament panel
- Cover workspace switching via feature test

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68be8f3469cc832ba8e83e5f6f7356af