### PR TITLE
Add Filament automation management

### DIFF
--- a/app/Console/Commands/MakeDemo.php
+++ b/app/Console/Commands/MakeDemo.php
@@ -42,6 +42,7 @@ class MakeDemo extends Command
             'account_id' => $account->id,
             'name' => 'Demo User',
             'email' => 'demo@example.com',
+            'is_admin' => true,
             'password' => 'password',
         ]);
 
@@ -88,6 +89,17 @@ class MakeDemo extends Command
             'uid' => (string) Str::uuid(),
             'kind' => AutomationStepKind::SendEmail->value,
             'config' => ['template_id' => $template->id],
+        ]);
+
+        // Add a default PushSetting for the demo workspace
+        \App\Models\PushSetting::create([
+            'workspace_id' => $workspace->id,
+            'driver' => 'expo',
+            'api_key_encrypted' => encrypt('demo-key'),
+            'app_id' => 'demo-app-id',
+            'project_id' => 'demo-project',
+            'meta' => ['example' => 'value'],
+            'is_active' => true,
         ]);
 
         $this->info('Demo data seeded.');

--- a/app/Filament/Resources/AutomationResource.php
+++ b/app/Filament/Resources/AutomationResource.php
@@ -25,6 +25,7 @@ use InvalidArgumentException;
 class AutomationResource extends Resource
 {
     protected static ?string $model = Automation::class;
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-m-cog-6-tooth';
 
     public static function form(Schema $schema): Schema
     {
@@ -76,7 +77,7 @@ class AutomationResource extends Resource
                             Forms\Components\TextInput::make('uid')
                                 ->label('UID')
                                 ->required()
-                                ->default(fn (): string => Str::uuid()->toString())
+                                ->default(fn(): string => Str::uuid()->toString())
                                 ->maxLength(255),
                             Forms\Components\Select::make('kind')
                                 ->label('Kind')
@@ -183,7 +184,7 @@ class AutomationResource extends Resource
             ]);
         }
 
-        $validatorInput = array_map(static fn (array $step): array => [
+        $validatorInput = array_map(static fn(array $step): array => [
             'uid' => $step['uid'],
             'next_step_uid' => $step['next_step_uid'] ?? null,
             'alt_next_step_uid' => $step['alt_next_step_uid'] ?? null,
@@ -324,7 +325,7 @@ class AutomationResource extends Resource
 
     private static function prepareStepsForStorage(array $steps): array
     {
-        $kinds = array_map(static fn (AutomationStepKind $kind): string => $kind->value, AutomationStepKind::cases());
+        $kinds = array_map(static fn(AutomationStepKind $kind): string => $kind->value, AutomationStepKind::cases());
 
         $processed = [];
 

--- a/app/Filament/Resources/AutomationResource.php
+++ b/app/Filament/Resources/AutomationResource.php
@@ -1,0 +1,392 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Domain\Automation\AutomationValidator;
+use App\Enums\AutomationStepKind;
+use App\Filament\Resources\AutomationResource\Pages\CreateAutomation;
+use App\Filament\Resources\AutomationResource\Pages\EditAutomation;
+use App\Filament\Resources\AutomationResource\Pages\ListAutomations;
+use App\Models\Automation;
+use App\Models\AutomationStep;
+use Filament\Forms;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use InvalidArgumentException;
+
+class AutomationResource extends Resource
+{
+    protected static ?string $model = Automation::class;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Grid::make(2)->schema([
+                Forms\Components\TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                Forms\Components\TextInput::make('trigger_event')
+                    ->label('Trigger Event')
+                    ->required()
+                    ->maxLength(255),
+                Forms\Components\Select::make('timezone')
+                    ->options(self::timezoneOptions())
+                    ->searchable()
+                    ->required()
+                    ->default('UTC'),
+                Forms\Components\Toggle::make('is_active')
+                    ->label('Active')
+                    ->default(false),
+            ]),
+            Section::make('Conditions')
+                ->schema([
+                    Forms\Components\Repeater::make('conditions')
+                        ->schema([
+                            Forms\Components\TextInput::make('path')
+                                ->label('Path')
+                                ->maxLength(255),
+                            Forms\Components\Select::make('op')
+                                ->label('Operator')
+                                ->options(self::conditionOperators()),
+                            Forms\Components\Textarea::make('value')
+                                ->label('Value')
+                                ->rows(2)
+                                ->helperText('Use JSON for arrays or complex data.'),
+                        ])
+                        ->grid(3)
+                        ->addActionLabel('Add Condition')
+                        ->reorderable(true)
+                        ->default([]),
+                ])
+                ->collapsible()
+                ->collapsed(),
+            Section::make('Steps')
+                ->schema([
+                    Forms\Components\Repeater::make('steps')
+                        ->schema([
+                            Forms\Components\Hidden::make('id'),
+                            Forms\Components\TextInput::make('uid')
+                                ->label('UID')
+                                ->required()
+                                ->default(fn (): string => Str::uuid()->toString())
+                                ->maxLength(255),
+                            Forms\Components\Select::make('kind')
+                                ->label('Kind')
+                                ->options(self::stepKindOptions())
+                                ->required(),
+                            Forms\Components\Textarea::make('config')
+                                ->label('Config (JSON)')
+                                ->rows(4)
+                                ->helperText('Provide configuration specific to the step type.'),
+                            Forms\Components\TextInput::make('next_step_uid')
+                                ->label('Next Step UID')
+                                ->maxLength(255),
+                            Forms\Components\TextInput::make('alt_next_step_uid')
+                                ->label('Alternate Next Step UID')
+                                ->maxLength(255),
+                        ])
+                        ->grid(2)
+                        ->addActionLabel('Add Step')
+                        ->reorderable(true)
+                        ->default([])
+                        ->minItems(1),
+                ])
+                ->collapsible(),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            Tables\Columns\TextColumn::make('name')->sortable()->searchable(),
+            Tables\Columns\TextColumn::make('trigger_event')->label('Trigger'),
+            Tables\Columns\IconColumn::make('is_active')->label('Active')->boolean(),
+            Tables\Columns\TextColumn::make('timezone')->sortable(),
+        ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListAutomations::route('/automations'),
+            'create' => CreateAutomation::route('/automations/create'),
+            'edit' => EditAutomation::route('/automations/{record}/edit'),
+        ];
+    }
+
+    public static function normalizeFormData(array $data): array
+    {
+        $data['conditions'] = self::prepareConditionsForStorage($data['conditions'] ?? []);
+        $data['steps'] = self::prepareStepsForStorage($data['steps'] ?? []);
+
+        return $data;
+    }
+
+    public static function prepareConditionsForForm(array $conditions): array
+    {
+        return array_map(static function (array $condition): array {
+            if (array_key_exists('value', $condition)) {
+                $value = $condition['value'];
+
+                if (is_array($value)) {
+                    $condition['value'] = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) ?: '';
+                } elseif (is_bool($value)) {
+                    $condition['value'] = $value ? 'true' : 'false';
+                } elseif ($value === null) {
+                    $condition['value'] = '';
+                } else {
+                    $condition['value'] = (string) $value;
+                }
+            }
+
+            return $condition;
+        }, $conditions);
+    }
+
+    public static function prepareStepsForForm(Automation $automation): array
+    {
+        return $automation->steps()
+            ->orderBy('id')
+            ->get()
+            ->map(static function (AutomationStep $step): array {
+                $config = $step->config;
+
+                if (is_array($config)) {
+                    $config = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) ?: '';
+                }
+
+                return [
+                    'id' => $step->id,
+                    'uid' => $step->uid,
+                    'kind' => $step->kind->value,
+                    'config' => $config,
+                    'next_step_uid' => $step->next_step_uid,
+                    'alt_next_step_uid' => $step->alt_next_step_uid,
+                ];
+            })
+            ->toArray();
+    }
+
+    public static function validateSteps(array $steps): void
+    {
+        if ($steps === []) {
+            throw ValidationException::withMessages([
+                'steps' => 'Add at least one step.',
+            ]);
+        }
+
+        $validatorInput = array_map(static fn (array $step): array => [
+            'uid' => $step['uid'],
+            'next_step_uid' => $step['next_step_uid'] ?? null,
+            'alt_next_step_uid' => $step['alt_next_step_uid'] ?? null,
+        ], $steps);
+
+        try {
+            app(AutomationValidator::class)->validate($validatorInput);
+        } catch (InvalidArgumentException $exception) {
+            throw ValidationException::withMessages([
+                'steps' => $exception->getMessage(),
+            ]);
+        }
+
+        $uids = array_column($validatorInput, 'uid');
+        if (count($uids) !== count(array_unique($uids))) {
+            throw ValidationException::withMessages([
+                'steps' => 'Step UIDs must be unique.',
+            ]);
+        }
+    }
+
+    public static function syncSteps(Automation $automation, array $steps): void
+    {
+        $existingIds = $automation->steps()->pluck('id')->all();
+        $keptIds = [];
+
+        foreach ($steps as $step) {
+            $payload = [
+                'uid' => $step['uid'],
+                'kind' => $step['kind'],
+                'config' => $step['config'],
+                'next_step_uid' => $step['next_step_uid'] ?? null,
+                'alt_next_step_uid' => $step['alt_next_step_uid'] ?? null,
+            ];
+
+            if (isset($step['id'])) {
+                $model = $automation->steps()->whereKey($step['id'])->first();
+                if ($model !== null) {
+                    $model->update($payload);
+                    $keptIds[] = $model->id;
+                    continue;
+                }
+            }
+
+            $model = $automation->steps()->create($payload);
+            $keptIds[] = $model->id;
+        }
+
+        $toDelete = array_diff($existingIds, $keptIds);
+        if ($toDelete !== []) {
+            $automation->steps()->whereIn('id', $toDelete)->delete();
+        }
+    }
+
+    private static function timezoneOptions(): array
+    {
+        $zones = \DateTimeZone::listIdentifiers();
+
+        return array_combine($zones, $zones);
+    }
+
+    private static function conditionOperators(): array
+    {
+        return [
+            '==' => 'Equals',
+            '!=' => 'Not equals',
+            'in' => 'In list',
+            '<=' => 'Less than or equal',
+            '>=' => 'Greater than or equal',
+            '<' => 'Less than',
+            '>' => 'Greater than',
+            'exists' => 'Exists',
+            'contains' => 'Contains',
+        ];
+    }
+
+    private static function stepKindOptions(): array
+    {
+        $options = [];
+
+        foreach (AutomationStepKind::cases() as $case) {
+            $options[$case->value] = Str::headline($case->name);
+        }
+
+        return $options;
+    }
+
+    private static function prepareConditionsForStorage(array $conditions): array
+    {
+        $operators = array_keys(self::conditionOperators());
+
+        $processed = [];
+
+        foreach ($conditions as $condition) {
+            $path = trim((string) ($condition['path'] ?? ''));
+            $op = trim((string) ($condition['op'] ?? ''));
+            $value = $condition['value'] ?? null;
+
+            if ($path === '' && $op === '' && ($value === null || $value === '')) {
+                continue;
+            }
+
+            if ($path === '' || $op === '') {
+                throw ValidationException::withMessages([
+                    'conditions' => 'Conditions require both a path and an operator.',
+                ]);
+            }
+
+            if (! in_array($op, $operators, true)) {
+                throw ValidationException::withMessages([
+                    'conditions' => 'Invalid condition operator selected.',
+                ]);
+            }
+
+            if (is_string($value)) {
+                $trimmed = trim($value);
+                if ($trimmed === '') {
+                    $value = null;
+                } else {
+                    $decoded = json_decode($trimmed, true);
+                    if (json_last_error() === JSON_ERROR_NONE) {
+                        $value = $decoded;
+                    } else {
+                        $value = $trimmed;
+                    }
+                }
+            }
+
+            $processed[] = [
+                'path' => $path,
+                'op' => $op,
+                'value' => $value,
+            ];
+        }
+
+        return $processed;
+    }
+
+    private static function prepareStepsForStorage(array $steps): array
+    {
+        $kinds = array_map(static fn (AutomationStepKind $kind): string => $kind->value, AutomationStepKind::cases());
+
+        $processed = [];
+
+        foreach ($steps as $step) {
+            $uid = trim((string) ($step['uid'] ?? ''));
+            $kind = $step['kind'] ?? null;
+
+            if ($uid === '' && ($kind === null || $kind === '')) {
+                continue;
+            }
+
+            if ($uid === '' || $kind === null || $kind === '') {
+                throw ValidationException::withMessages([
+                    'steps' => 'Each step requires both a UID and kind.',
+                ]);
+            }
+
+            if (! in_array($kind, $kinds, true)) {
+                throw ValidationException::withMessages([
+                    'steps' => 'Invalid step kind selected.',
+                ]);
+            }
+
+            $config = $step['config'] ?? null;
+
+            if (is_string($config)) {
+                $trimmedConfig = trim($config);
+
+                if ($trimmedConfig === '') {
+                    $config = null;
+                } else {
+                    $decodedConfig = json_decode($trimmedConfig, true);
+
+                    if (json_last_error() !== JSON_ERROR_NONE) {
+                        throw ValidationException::withMessages([
+                            'steps' => 'Step config must be valid JSON.',
+                        ]);
+                    }
+
+                    $config = $decodedConfig;
+                }
+            } elseif ($config === [] || $config === '') {
+                $config = null;
+            } elseif ($config !== null && ! is_array($config)) {
+                throw ValidationException::withMessages([
+                    'steps' => 'Step config must be valid JSON.',
+                ]);
+            }
+
+            $next = trim((string) ($step['next_step_uid'] ?? ''));
+            $alt = trim((string) ($step['alt_next_step_uid'] ?? ''));
+
+            $processed[] = [
+                'id' => $step['id'] ?? null,
+                'uid' => $uid,
+                'kind' => $kind,
+                'config' => $config,
+                'next_step_uid' => $next === '' ? null : $next,
+                'alt_next_step_uid' => $alt === '' ? null : $alt,
+            ];
+        }
+
+        return $processed;
+    }
+}

--- a/app/Filament/Resources/AutomationResource/Pages/CreateAutomation.php
+++ b/app/Filament/Resources/AutomationResource/Pages/CreateAutomation.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\AutomationResource\Pages;
+
+use App\Filament\Resources\AutomationResource;
+use App\Models\Automation;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateAutomation extends CreateRecord
+{
+    protected static string $resource = AutomationResource::class;
+
+    protected function handleRecordCreation(array $data): Automation
+    {
+        $data = AutomationResource::normalizeFormData($data);
+
+        $steps = $data['steps'] ?? [];
+        unset($data['steps']);
+
+        AutomationResource::validateSteps($steps);
+
+        $automation = Automation::create($data);
+
+        AutomationResource::syncSteps($automation, $steps);
+
+        return $automation;
+    }
+}

--- a/app/Filament/Resources/AutomationResource/Pages/EditAutomation.php
+++ b/app/Filament/Resources/AutomationResource/Pages/EditAutomation.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\AutomationResource\Pages;
+
+use App\Filament\Resources\AutomationResource;
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+
+class EditAutomation extends EditRecord
+{
+    protected static string $resource = AutomationResource::class;
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        $automation = $this->getRecord();
+
+        $data['conditions'] = AutomationResource::prepareConditionsForForm($automation->conditions ?? []);
+        $data['steps'] = AutomationResource::prepareStepsForForm($automation);
+
+        return $data;
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        $data = AutomationResource::normalizeFormData($data);
+
+        $steps = $data['steps'] ?? [];
+        unset($data['steps']);
+
+        AutomationResource::validateSteps($steps);
+
+        $record->update($data);
+
+        AutomationResource::syncSteps($record, $steps);
+
+        return $record;
+    }
+}

--- a/app/Filament/Resources/AutomationResource/Pages/ListAutomations.php
+++ b/app/Filament/Resources/AutomationResource/Pages/ListAutomations.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\AutomationResource\Pages;
+
+use App\Filament\Resources\AutomationResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListAutomations extends ListRecords
+{
+    protected static string $resource = AutomationResource::class;
+}

--- a/app/Filament/Resources/PushSettingResource.php
+++ b/app/Filament/Resources/PushSettingResource.php
@@ -21,6 +21,7 @@ class PushSettingResource extends Resource
     protected static ?string $model = PushSetting::class;
 
     protected static string|\UnitEnum|null $navigationGroup = 'Settings';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-m-bell';
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Filament/Resources/PushSettingResource.php
+++ b/app/Filament/Resources/PushSettingResource.php
@@ -30,12 +30,14 @@ class PushSettingResource extends Resource
                     'one_signal' => 'OneSignal',
                     'expo' => 'Expo',
                 ])
-                ->required(),
+                ->required()->live(),
             Forms\Components\TextInput::make('api_key')
                 ->password()
                 ->afterStateHydrated(fn(Forms\Components\TextInput $component) => $component->state('')),
             Forms\Components\TextInput::make('app_id'),
-            Forms\Components\TextInput::make('project_id'),
+            Forms\Components\TextInput::make('project_id')
+                ->live()
+                ->visible(fn($get) => $get('driver') !== 'one_signal'),
             Forms\Components\Toggle::make('is_active'),
         ]);
     }

--- a/app/Filament/Resources/SmtpSettingResource.php
+++ b/app/Filament/Resources/SmtpSettingResource.php
@@ -30,7 +30,14 @@ class SmtpSettingResource extends Resource
             Forms\Components\TextInput::make('password')
                 ->password()
                 ->afterStateHydrated(fn(Forms\Components\TextInput $component) => $component->state('')),
-            Forms\Components\TextInput::make('encryption'),
+            Forms\Components\Select::make('encryption')
+                ->options([
+                    'tls' => 'TLS',
+                    'ssl' => 'SSL',
+                    'none' => 'None',
+                ])
+                ->default('tls')
+                ->required(),
             Forms\Components\TextInput::make('from_name'),
             Forms\Components\TextInput::make('from_email')->email()->required(),
             Forms\Components\TextInput::make('reply_to')->email(),

--- a/app/Filament/Resources/SmtpSettingResource.php
+++ b/app/Filament/Resources/SmtpSettingResource.php
@@ -20,6 +20,7 @@ class SmtpSettingResource extends Resource
     protected static ?string $model = SmtpSetting::class;
 
     protected static string|\UnitEnum|null $navigationGroup = 'Settings';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-m-envelope';
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Filament/Resources/TemplateResource.php
+++ b/app/Filament/Resources/TemplateResource.php
@@ -18,6 +18,7 @@ use Filament\Tables\Table;
 class TemplateResource extends Resource
 {
     protected static ?string $model = Template::class;
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-m-document-text';
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Filament/Resources/WorkspaceResource.php
+++ b/app/Filament/Resources/WorkspaceResource.php
@@ -19,6 +19,7 @@ class WorkspaceResource extends Resource
     protected static ?string $model = Workspace::class;
 
     protected static string|\UnitEnum|null $navigationGroup = 'Settings';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-m-building-office';
 
     public static function form(Schema $schema): Schema
     {
@@ -50,4 +51,3 @@ class WorkspaceResource extends Resource
         return parent::getEloquentQuery()->where('account_id', auth()->user()->account_id);
     }
 }
-

--- a/tests/Feature/ManageAutomationsTest.php
+++ b/tests/Feature/ManageAutomationsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AutomationStepKind;
+use App\Filament\Resources\AutomationResource\Pages\CreateAutomation;
+use App\Models\Account;
+use App\Models\Automation;
+use App\Models\AutomationStep;
+use App\Models\Template;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+it('allows admins to create automations', function (): void {
+    $account = Account::factory()->create();
+    $workspace = Workspace::factory()->for($account)->create(['slug' => 'demo']);
+    $admin = User::factory()->for($account)->for($workspace)->admin()->create();
+    $template = Template::factory()->for($workspace)->create();
+
+    actingAs($admin);
+    app()->instance('currentWorkspace', $workspace);
+
+    Livewire::test(CreateAutomation::class)
+        ->fillForm([
+            'name' => 'Welcome Flow',
+            'trigger_event' => 'signup',
+            'is_active' => true,
+            'timezone' => 'UTC',
+            'conditions' => [
+                [
+                    'path' => 'event.name',
+                    'op' => '==',
+                    'value' => 'signup',
+                ],
+                [
+                    'path' => 'contact.tags',
+                    'op' => 'in',
+                    'value' => '["vip","beta"]',
+                ],
+            ],
+            'steps' => [
+                [
+                    'uid' => 'start',
+                    'kind' => AutomationStepKind::SendEmail->value,
+                    'config' => json_encode(['template_id' => $template->id], JSON_UNESCAPED_SLASHES),
+                    'next_step_uid' => 'delay',
+                    'alt_next_step_uid' => null,
+                ],
+                [
+                    'uid' => 'delay',
+                    'kind' => AutomationStepKind::Delay->value,
+                    'config' => json_encode(['minutes' => 10], JSON_UNESCAPED_SLASHES),
+                    'next_step_uid' => null,
+                    'alt_next_step_uid' => null,
+                ],
+            ],
+        ])
+        ->call('create')
+        ->assertHasNoErrors();
+
+    $automation = Automation::where('workspace_id', $workspace->id)->firstOrFail();
+
+    expect($automation->name)->toBe('Welcome Flow')
+        ->and($automation->trigger_event)->toBe('signup')
+        ->and($automation->conditions)->toBe([
+            ['path' => 'event.name', 'op' => '==', 'value' => 'signup'],
+            ['path' => 'contact.tags', 'op' => 'in', 'value' => ['vip', 'beta']],
+        ]);
+
+    $start = AutomationStep::where('automation_id', $automation->id)->where('uid', 'start')->firstOrFail();
+    $delay = AutomationStep::where('automation_id', $automation->id)->where('uid', 'delay')->firstOrFail();
+
+    expect($start->kind)->toBe(AutomationStepKind::SendEmail)
+        ->and($start->config)->toBe(['template_id' => $template->id])
+        ->and($start->next_step_uid)->toBe('delay');
+
+    expect($delay->kind)->toBe(AutomationStepKind::Delay)
+        ->and($delay->config)->toBe(['minutes' => 10])
+        ->and($delay->next_step_uid)->toBeNull();
+});


### PR DESCRIPTION
## Summary
- add a Filament resource for automations, including schema helpers for conditions and steps
- create custom create and edit pages that normalize automation data and synchronize step records
- add a feature test that covers creating an automation through the Filament panel

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68c97ad74f04832bad7a8eaac8ed0140