### PR TITLE
Refine automation step configuration UI

### DIFF
--- a/tests/Feature/ManageAutomationsTest.php
+++ b/tests/Feature/ManageAutomationsTest.php
@@ -48,14 +48,14 @@ it('allows admins to create automations', function (): void {
                 [
                     'uid' => 'start',
                     'kind' => AutomationStepKind::SendEmail->value,
-                    'config' => json_encode(['template_id' => $template->id], JSON_UNESCAPED_SLASHES),
+                    'config' => ['template_id' => $template->id],
                     'next_step_uid' => 'delay',
                     'alt_next_step_uid' => null,
                 ],
                 [
                     'uid' => 'delay',
                     'kind' => AutomationStepKind::Delay->value,
-                    'config' => json_encode(['minutes' => 10], JSON_UNESCAPED_SLASHES),
+                    'config' => ['minutes' => 10],
                     'next_step_uid' => null,
                     'alt_next_step_uid' => null,
                 ],


### PR DESCRIPTION
## Summary
- update the automation steps repeater to react to step kind and present dedicated config inputs for email, delay, and push notification actions
- hydrate and dehydrate the new structured config arrays when loading and saving steps, including validating template selection, delay values, and push payloads
- adjust the automation feature test to submit the structured config payload

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9bb6fcd74832ba32cea37225f7586