### PR TITLE
Refine automation condition builder

### DIFF
--- a/tests/Feature/ManageAutomationsTest.php
+++ b/tests/Feature/ManageAutomationsTest.php
@@ -40,14 +40,24 @@ it('allows admins to create automations', function (): void {
             'timezone' => 'UTC',
             'conditions' => [
                 [
-                    'path' => 'event.name',
+                    'attribute' => 'event.name',
+                    'custom_path' => null,
                     'op' => '==',
-                    'value' => 'signup',
+                    'type' => 'string',
+                    'value_text' => 'signup',
+                    'value_number' => null,
+                    'value_boolean' => false,
+                    'value_array' => [],
                 ],
                 [
-                    'path' => 'contact.tags',
+                    'attribute' => 'contact.tags',
+                    'custom_path' => null,
                     'op' => 'in',
-                    'value' => '["vip","beta"]',
+                    'type' => 'array',
+                    'value_text' => '',
+                    'value_number' => null,
+                    'value_boolean' => false,
+                    'value_array' => ['vip', 'beta'],
                 ],
             ],
             'steps' => [


### PR DESCRIPTION
## Summary
- redesign the automation condition repeater with curated attribute selection, advanced custom paths, and typed value inputs
- hydrate and dehydrate condition data based on the selected value type, converting numbers, booleans, and lists automatically
- update the automation management feature test to submit the new typed condition payload

## Testing
- php artisan test *(warnings: missing `.env` for many suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6101f3e0832b97890a1ac7410ba3