### PR TITLE
Add business Filament panel with UGC management

### DIFF
--- a/app/Enums/UgcApplicationStatus.php
+++ b/app/Enums/UgcApplicationStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum UgcApplicationStatus: string
+{
+    case Pending = 'pending';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pending => 'Pending',
+            self::Approved => 'Approved',
+            self::Rejected => 'Rejected',
+        };
+    }
+}

--- a/app/Enums/UgcSubmissionStatus.php
+++ b/app/Enums/UgcSubmissionStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum UgcSubmissionStatus: string
+{
+    case Submitted = 'submitted';
+    case Approved = 'approved';
+    case RevisionsRequested = 'revisions_requested';
+    case Rejected = 'rejected';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Submitted => 'Submitted',
+            self::Approved => 'Approved',
+            self::RevisionsRequested => 'Revisions Requested',
+            self::Rejected => 'Rejected',
+        };
+    }
+}

--- a/app/Enums/UgcTaskStatus.php
+++ b/app/Enums/UgcTaskStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum UgcTaskStatus: string
+{
+    case Draft = 'draft';
+    case Published = 'published';
+    case Closed = 'closed';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Draft => 'Draft',
+            self::Published => 'Published',
+            self::Closed => 'Closed',
+        };
+    }
+}

--- a/app/Filament/Business/Pages/Dashboard.php
+++ b/app/Filament/Business/Pages/Dashboard.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Pages;
+
+use Filament\Pages\Dashboard as BaseDashboard;
+
+class Dashboard extends BaseDashboard
+{
+}

--- a/app/Filament/Business/Resources/BusinessProfileResource.php
+++ b/app/Filament/Business/Resources/BusinessProfileResource.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources;
+
+use App\Filament\Business\Resources\BusinessProfileResource\Pages;
+use App\Models\Account;
+use Filament\Forms;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class BusinessProfileResource extends Resource
+{
+    protected static ?string $model = Account::class;
+
+    protected static ?string $navigationIcon = 'heroicon-m-building-office';
+
+    protected static ?string $navigationGroup = 'Settings';
+
+    protected static ?string $navigationLabel = 'Business Profile';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Brand identity')
+                ->schema([
+                    Grid::make(2)->schema([
+                        Forms\Components\TextInput::make('name')
+                            ->label('Business name')
+                            ->required()
+                            ->maxLength(255)
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(function (?string $state, Get $get, Set $set): void {
+                                if (blank($get('slug')) && filled($state)) {
+                                    $set('slug', str()->slug($state));
+                                }
+                            }),
+                        Forms\Components\TextInput::make('slug')
+                            ->label('Slug')
+                            ->required()
+                            ->maxLength(255)
+                            ->unique(ignoreRecord: true),
+                        Forms\Components\TextInput::make('website_url')
+                            ->label('Website URL')
+                            ->url()
+                            ->maxLength(255),
+                        Forms\Components\TextInput::make('logo_url')
+                            ->label('Logo URL')
+                            ->url()
+                            ->maxLength(255),
+                    ]),
+                    Forms\Components\Textarea::make('description')
+                        ->label('About the business')
+                        ->rows(4)
+                        ->maxLength(1000)
+                        ->columnSpanFull(),
+                ]),
+            Section::make('Contact')
+                ->schema([
+                    Grid::make(2)->schema([
+                        Forms\Components\TextInput::make('support_email')
+                            ->label('Support email')
+                            ->email()
+                            ->maxLength(255),
+                        Forms\Components\TextInput::make('support_phone')
+                            ->label('Support phone')
+                            ->tel()
+                            ->maxLength(255),
+                    ]),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->label('Business')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('slug')
+                    ->sortable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('website_url')
+                    ->label('Website')
+                    ->url(fn (Account $record): ?string => $record->website_url)
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('support_email')
+                    ->label('Support email')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('support_phone')
+                    ->label('Support phone')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        $user = auth()->user();
+
+        return parent::getEloquentQuery()
+            ->when($user !== null, fn (Builder $query): Builder => $query->whereKey($user->account_id));
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canDelete(Model $record): bool
+    {
+        return false;
+    }
+
+    public static function canForceDelete(Model $record): bool
+    {
+        return false;
+    }
+
+    public static function canDeleteAny(): bool
+    {
+        return false;
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListBusinessProfiles::route('/'),
+            'edit' => Pages\EditBusinessProfile::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Business/Resources/BusinessProfileResource/Pages/EditBusinessProfile.php
+++ b/app/Filament/Business/Resources/BusinessProfileResource/Pages/EditBusinessProfile.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources\BusinessProfileResource\Pages;
+
+use App\Filament\Business\Resources\BusinessProfileResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditBusinessProfile extends EditRecord
+{
+    protected static string $resource = BusinessProfileResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Business/Resources/BusinessProfileResource/Pages/ListBusinessProfiles.php
+++ b/app/Filament/Business/Resources/BusinessProfileResource/Pages/ListBusinessProfiles.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources\BusinessProfileResource\Pages;
+
+use App\Filament\Business\Resources\BusinessProfileResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListBusinessProfiles extends ListRecords
+{
+    protected static string $resource = BusinessProfileResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+
+    public function mount(): void
+    {
+        parent::mount();
+
+        $record = (clone $this->getTableQuery())->first();
+
+        if ($record !== null) {
+            $this->redirect(BusinessProfileResource::getUrl('edit', ['record' => $record]));
+        }
+    }
+}

--- a/app/Filament/Business/Resources/UgcApplicationResource.php
+++ b/app/Filament/Business/Resources/UgcApplicationResource.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources;
+
+use App\Enums\UgcApplicationStatus;
+use App\Filament\Business\Resources\UgcApplicationResource\Pages;
+use App\Models\UgcApplication;
+use Filament\Forms;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Arr;
+
+class UgcApplicationResource extends Resource
+{
+    protected static ?string $model = UgcApplication::class;
+
+    protected static ?string $navigationIcon = 'heroicon-m-document-text';
+
+    protected static ?string $navigationGroup = 'UGC';
+
+    protected static ?string $navigationLabel = 'Applications';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Application details')
+                ->schema([
+                    Grid::make(2)->schema([
+                        Forms\Components\Select::make('ugc_task_id')
+                            ->label('Task')
+                            ->relationship('task', 'title')
+                            ->searchable()
+                            ->preload()
+                            ->required(),
+                        Forms\Components\Select::make('status')
+                            ->options(self::statusOptions())
+                            ->enum(UgcApplicationStatus::class)
+                            ->required(),
+                        Forms\Components\DateTimePicker::make('submitted_at')
+                            ->label('Submitted at')
+                            ->seconds(false),
+                    ]),
+                    Grid::make(2)->schema([
+                        Forms\Components\TextInput::make('creator_name')
+                            ->label('Creator name')
+                            ->required()
+                            ->maxLength(255),
+                        Forms\Components\TextInput::make('creator_email')
+                            ->label('Creator email')
+                            ->email()
+                            ->required()
+                            ->maxLength(255),
+                    ]),
+                    Forms\Components\Textarea::make('pitch')
+                        ->label('Pitch')
+                        ->rows(5)
+                        ->columnSpanFull(),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('task.title')
+                    ->label('Task')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('creator_name')
+                    ->label('Creator')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('creator_email')
+                    ->label('Email')
+                    ->searchable(),
+                Tables\Columns\BadgeColumn::make('status')
+                    ->colors([
+                        'warning' => UgcApplicationStatus::Pending->value,
+                        'success' => UgcApplicationStatus::Approved->value,
+                        'danger' => UgcApplicationStatus::Rejected->value,
+                    ])
+                    ->formatStateUsing(function (UgcApplicationStatus|string|null $state): string {
+                        if ($state instanceof UgcApplicationStatus) {
+                            return $state->label();
+                        }
+
+                        if (is_string($state) && $state !== '') {
+                            return UgcApplicationStatus::from($state)->label();
+                        }
+
+                        return UgcApplicationStatus::Pending->label();
+                    })
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('submitted_at')
+                    ->label('Submitted')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(self::statusOptions()),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListUgcApplications::route('/'),
+            'create' => Pages\CreateUgcApplication::route('/create'),
+            'edit' => Pages\EditUgcApplication::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected static function statusOptions(): array
+    {
+        return Arr::mapWithKeys(UgcApplicationStatus::cases(), fn (UgcApplicationStatus $status): array => [
+            $status->value => $status->label(),
+        ]);
+    }
+}

--- a/app/Filament/Business/Resources/UgcApplicationResource/Pages/CreateUgcApplication.php
+++ b/app/Filament/Business/Resources/UgcApplicationResource/Pages/CreateUgcApplication.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources\UgcApplicationResource\Pages;
+
+use App\Filament\Business\Resources\UgcApplicationResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateUgcApplication extends CreateRecord
+{
+    protected static string $resource = UgcApplicationResource::class;
+}

--- a/app/Filament/Business/Resources/UgcApplicationResource/Pages/EditUgcApplication.php
+++ b/app/Filament/Business/Resources/UgcApplicationResource/Pages/EditUgcApplication.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources\UgcApplicationResource\Pages;
+
+use App\Filament\Business\Resources\UgcApplicationResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditUgcApplication extends EditRecord
+{
+    protected static string $resource = UgcApplicationResource::class;
+}

--- a/app/Filament/Business/Resources/UgcApplicationResource/Pages/ListUgcApplications.php
+++ b/app/Filament/Business/Resources/UgcApplicationResource/Pages/ListUgcApplications.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources\UgcApplicationResource\Pages;
+
+use App\Filament\Business\Resources\UgcApplicationResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUgcApplications extends ListRecords
+{
+    protected static string $resource = UgcApplicationResource::class;
+}

--- a/app/Filament/Business/Resources/UgcSubmissionResource.php
+++ b/app/Filament/Business/Resources/UgcSubmissionResource.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources;
+
+use App\Enums\UgcSubmissionStatus;
+use App\Filament\Business\Resources\UgcSubmissionResource\Pages;
+use App\Models\UgcApplication;
+use App\Models\UgcSubmission;
+use Filament\Forms;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Arr;
+
+class UgcSubmissionResource extends Resource
+{
+    protected static ?string $model = UgcSubmission::class;
+
+    protected static ?string $navigationIcon = 'heroicon-m-paper-airplane';
+
+    protected static ?string $navigationGroup = 'UGC';
+
+    protected static ?string $navigationLabel = 'Submissions';
+
+    protected static ?int $navigationSort = 2;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Submission details')
+                ->schema([
+                    Grid::make(2)->schema([
+                        Forms\Components\Select::make('ugc_task_id')
+                            ->label('Task')
+                            ->relationship('task', 'title')
+                            ->searchable()
+                            ->preload()
+                            ->required(),
+                        Forms\Components\Select::make('ugc_application_id')
+                            ->label('Application')
+                            ->relationship('application', 'creator_name')
+                            ->searchable()
+                            ->preload()
+                            ->getOptionLabelFromRecordUsing(function (UgcApplication $record): string {
+                                if (filled($record->creator_email)) {
+                                    return sprintf('%s (%s)', $record->creator_name, $record->creator_email);
+                                }
+
+                                return $record->creator_name;
+                            })
+                            ->helperText('Optional link to the originating application.')
+                            ->nullable(),
+                        Forms\Components\Select::make('status')
+                            ->options(self::statusOptions())
+                            ->enum(UgcSubmissionStatus::class)
+                            ->required(),
+                        Forms\Components\DateTimePicker::make('submitted_at')
+                            ->label('Submitted at')
+                            ->seconds(false),
+                    ]),
+                    Forms\Components\TextInput::make('content_url')
+                        ->label('Content URL')
+                        ->url()
+                        ->required()
+                        ->maxLength(2048)
+                        ->columnSpanFull(),
+                    Forms\Components\Textarea::make('notes')
+                        ->rows(4)
+                        ->columnSpanFull(),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('task.title')
+                    ->label('Task')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('application.creator_name')
+                    ->label('Application')
+                    ->toggleable()
+                    ->limit(30),
+                Tables\Columns\TextColumn::make('content_url')
+                    ->label('Content')
+                    ->url(fn (UgcSubmission $record): ?string => $record->content_url)
+                    ->limit(30)
+                    ->wrap(),
+                Tables\Columns\BadgeColumn::make('status')
+                    ->colors([
+                        'warning' => UgcSubmissionStatus::Submitted->value,
+                        'success' => UgcSubmissionStatus::Approved->value,
+                        'danger' => UgcSubmissionStatus::Rejected->value,
+                        'gray' => UgcSubmissionStatus::RevisionsRequested->value,
+                    ])
+                    ->formatStateUsing(function (UgcSubmissionStatus|string|null $state): string {
+                        if ($state instanceof UgcSubmissionStatus) {
+                            return $state->label();
+                        }
+
+                        if (is_string($state) && $state !== '') {
+                            return UgcSubmissionStatus::from($state)->label();
+                        }
+
+                        return UgcSubmissionStatus::Submitted->label();
+                    })
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('submitted_at')
+                    ->label('Submitted at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(self::statusOptions()),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListUgcSubmissions::route('/'),
+            'create' => Pages\CreateUgcSubmission::route('/create'),
+            'edit' => Pages\EditUgcSubmission::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected static function statusOptions(): array
+    {
+        return Arr::mapWithKeys(UgcSubmissionStatus::cases(), fn (UgcSubmissionStatus $status): array => [
+            $status->value => $status->label(),
+        ]);
+    }
+}

--- a/app/Filament/Business/Resources/UgcSubmissionResource/Pages/CreateUgcSubmission.php
+++ b/app/Filament/Business/Resources/UgcSubmissionResource/Pages/CreateUgcSubmission.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources\UgcSubmissionResource\Pages;
+
+use App\Filament\Business\Resources\UgcSubmissionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateUgcSubmission extends CreateRecord
+{
+    protected static string $resource = UgcSubmissionResource::class;
+}

--- a/app/Filament/Business/Resources/UgcSubmissionResource/Pages/EditUgcSubmission.php
+++ b/app/Filament/Business/Resources/UgcSubmissionResource/Pages/EditUgcSubmission.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources\UgcSubmissionResource\Pages;
+
+use App\Filament\Business\Resources\UgcSubmissionResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditUgcSubmission extends EditRecord
+{
+    protected static string $resource = UgcSubmissionResource::class;
+}

--- a/app/Filament/Business/Resources/UgcSubmissionResource/Pages/ListUgcSubmissions.php
+++ b/app/Filament/Business/Resources/UgcSubmissionResource/Pages/ListUgcSubmissions.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources\UgcSubmissionResource\Pages;
+
+use App\Filament\Business\Resources\UgcSubmissionResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUgcSubmissions extends ListRecords
+{
+    protected static string $resource = UgcSubmissionResource::class;
+}

--- a/app/Filament/Business/Resources/UgcTaskResource.php
+++ b/app/Filament/Business/Resources/UgcTaskResource.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources;
+
+use App\Enums\UgcTaskStatus;
+use App\Filament\Business\Resources\UgcTaskResource\Pages;
+use App\Models\UgcTask;
+use Filament\Forms;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Arr;
+use Illuminate\Validation\Rule;
+
+class UgcTaskResource extends Resource
+{
+    protected static ?string $model = UgcTask::class;
+
+    protected static ?string $navigationIcon = 'heroicon-m-clipboard-document-check';
+
+    protected static ?string $navigationGroup = 'UGC';
+
+    protected static ?string $navigationLabel = 'Tasks';
+
+    protected static ?int $navigationSort = 0;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Task details')
+                ->schema([
+                    Grid::make(2)->schema([
+                        Forms\Components\TextInput::make('title')
+                            ->required()
+                            ->maxLength(255)
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(function (?string $state, Get $get, Set $set): void {
+                                if (blank($get('slug')) && filled($state)) {
+                                    $set('slug', str()->slug($state));
+                                }
+                            }),
+                        Forms\Components\TextInput::make('slug')
+                            ->required()
+                            ->maxLength(255)
+                            ->unique(ignoreRecord: true, modifyRuleUsing: function (Rule $rule): Rule {
+                                $workspaceId = currentWorkspace()?->id;
+
+                                return $workspaceId === null
+                                    ? $rule
+                                    : $rule->where('workspace_id', $workspaceId);
+                            }),
+                        Forms\Components\Select::make('status')
+                            ->options(self::statusOptions())
+                            ->enum(UgcTaskStatus::class)
+                            ->required(),
+                        Forms\Components\TextInput::make('reward')
+                            ->label('Reward')
+                            ->maxLength(255),
+                    ]),
+                    Forms\Components\Textarea::make('brief')
+                        ->rows(4)
+                        ->columnSpanFull(),
+                    Forms\Components\Textarea::make('requirements')
+                        ->rows(4)
+                        ->columnSpanFull(),
+                ]),
+            Section::make('Schedule')
+                ->schema([
+                    Grid::make(2)->schema([
+                        Forms\Components\DateTimePicker::make('published_at')
+                            ->label('Publish at')
+                            ->seconds(false),
+                        Forms\Components\DateTimePicker::make('deadline_at')
+                            ->label('Deadline')
+                            ->seconds(false),
+                    ]),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\BadgeColumn::make('status')
+                    ->colors([
+                        'gray' => UgcTaskStatus::Draft->value,
+                        'success' => UgcTaskStatus::Published->value,
+                        'danger' => UgcTaskStatus::Closed->value,
+                    ])
+                    ->formatStateUsing(function (UgcTaskStatus|string|null $state): string {
+                        if ($state instanceof UgcTaskStatus) {
+                            return $state->label();
+                        }
+
+                        if (is_string($state) && $state !== '') {
+                            return UgcTaskStatus::from($state)->label();
+                        }
+
+                        return UgcTaskStatus::Draft->label();
+                    })
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('reward')
+                    ->toggleable()
+                    ->limit(30),
+                Tables\Columns\TextColumn::make('published_at')
+                    ->label('Published')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('deadline_at')
+                    ->label('Deadline')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(self::statusOptions()),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListUgcTasks::route('/'),
+            'create' => Pages\CreateUgcTask::route('/create'),
+            'edit' => Pages\EditUgcTask::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected static function statusOptions(): array
+    {
+        return Arr::mapWithKeys(UgcTaskStatus::cases(), fn (UgcTaskStatus $status): array => [
+            $status->value => $status->label(),
+        ]);
+    }
+}

--- a/app/Filament/Business/Resources/UgcTaskResource/Pages/CreateUgcTask.php
+++ b/app/Filament/Business/Resources/UgcTaskResource/Pages/CreateUgcTask.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources\UgcTaskResource\Pages;
+
+use App\Filament\Business\Resources\UgcTaskResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateUgcTask extends CreateRecord
+{
+    protected static string $resource = UgcTaskResource::class;
+}

--- a/app/Filament/Business/Resources/UgcTaskResource/Pages/EditUgcTask.php
+++ b/app/Filament/Business/Resources/UgcTaskResource/Pages/EditUgcTask.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources\UgcTaskResource\Pages;
+
+use App\Filament\Business\Resources\UgcTaskResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditUgcTask extends EditRecord
+{
+    protected static string $resource = UgcTaskResource::class;
+}

--- a/app/Filament/Business/Resources/UgcTaskResource/Pages/ListUgcTasks.php
+++ b/app/Filament/Business/Resources/UgcTaskResource/Pages/ListUgcTasks.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Business\Resources\UgcTaskResource\Pages;
+
+use App\Filament\Business\Resources\UgcTaskResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUgcTasks extends ListRecords
+{
+    protected static string $resource = UgcTaskResource::class;
+}

--- a/app/Filament/BusinessPanelProvider.php
+++ b/app/Filament/BusinessPanelProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament;
+
+use App\Models\Workspace;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Http\Middleware\Authenticate;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Support\Colors\Color;
+use Illuminate\Http\Request;
+
+class BusinessPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('business')
+            ->path('business')
+            ->login()
+            ->colors([
+                'primary' => Color::Indigo,
+            ])
+            ->middleware([
+                'web',
+                'workspace',
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ])
+            ->userMenuItems([
+                Action::make('workspace')
+                    ->label(fn (): string => currentWorkspace()?->name ?? 'Workspace')
+                    ->icon('heroicon-m-rectangle-stack')
+                    ->form([
+                        Select::make('workspace')
+                            ->label('Workspace')
+                            ->options(fn (): array => auth()->user()?->account?->workspaces()?->pluck('name', 'slug')?->toArray() ?? [])
+                            ->default(fn (): ?string => session('workspace')),
+                    ])
+                    ->action(function (array $data, Request $request): void {
+                        $workspace = Workspace::where('slug', $data['workspace'])->first();
+                        if ($workspace !== null && $workspace->account_id === $request->user()?->account_id) {
+                            $request->session()->put('workspace', $workspace->slug);
+                        }
+                    }),
+            ])
+            ->discoverResources(in: app_path('Filament/Business/Resources'), for: 'App\\Filament\\Business\\Resources')
+            ->discoverPages(in: app_path('Filament/Business/Pages'), for: 'App\\Filament\\Business\\Pages')
+            ->discoverWidgets(in: app_path('Filament/Business/Widgets'), for: 'App\\Filament\\Business\\Widgets')
+            ->pages([
+                \App\Filament\Business\Pages\Dashboard::class,
+            ]);
+    }
+}

--- a/app/Models/UgcApplication.php
+++ b/app/Models/UgcApplication.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\UgcApplicationStatus;
+use App\Models\Concerns\ScopedToWorkspace;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class UgcApplication extends Model
+{
+    use HasFactory;
+    use ScopedToWorkspace;
+
+    protected $fillable = [
+        'workspace_id',
+        'ugc_task_id',
+        'creator_name',
+        'creator_email',
+        'pitch',
+        'status',
+        'submitted_at',
+    ];
+
+    protected $casts = [
+        'submitted_at' => 'datetime',
+        'status' => UgcApplicationStatus::class,
+    ];
+
+    public function task(): BelongsTo
+    {
+        return $this->belongsTo(UgcTask::class, 'ugc_task_id');
+    }
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function submission(): HasOne
+    {
+        return $this->hasOne(UgcSubmission::class, 'ugc_application_id');
+    }
+}

--- a/app/Models/UgcSubmission.php
+++ b/app/Models/UgcSubmission.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\UgcSubmissionStatus;
+use App\Models\Concerns\ScopedToWorkspace;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UgcSubmission extends Model
+{
+    use HasFactory;
+    use ScopedToWorkspace;
+
+    protected $fillable = [
+        'workspace_id',
+        'ugc_task_id',
+        'ugc_application_id',
+        'content_url',
+        'notes',
+        'status',
+        'submitted_at',
+    ];
+
+    protected $casts = [
+        'submitted_at' => 'datetime',
+        'status' => UgcSubmissionStatus::class,
+    ];
+
+    public function task(): BelongsTo
+    {
+        return $this->belongsTo(UgcTask::class, 'ugc_task_id');
+    }
+
+    public function application(): BelongsTo
+    {
+        return $this->belongsTo(UgcApplication::class, 'ugc_application_id');
+    }
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+}

--- a/app/Models/UgcTask.php
+++ b/app/Models/UgcTask.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\UgcTaskStatus;
+use App\Models\Concerns\ScopedToWorkspace;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class UgcTask extends Model
+{
+    use HasFactory;
+    use ScopedToWorkspace;
+
+    protected $fillable = [
+        'workspace_id',
+        'title',
+        'slug',
+        'brief',
+        'requirements',
+        'reward',
+        'status',
+        'published_at',
+        'deadline_at',
+    ];
+
+    protected $casts = [
+        'published_at' => 'datetime',
+        'deadline_at' => 'datetime',
+        'status' => UgcTaskStatus::class,
+    ];
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function applications(): HasMany
+    {
+        return $this->hasMany(UgcApplication::class);
+    }
+
+    public function submissions(): HasMany
+    {
+        return $this->hasMany(UgcSubmission::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -68,6 +68,10 @@ class User extends Authenticatable implements FilamentUser
     }
     public function canAccessPanel(Panel $panel): bool
     {
-        return true; // Adjust logic as needed for your application
+        return match ($panel->getId()) {
+            'admin' => (bool) $this->is_admin,
+            'business' => $this->account_id !== null,
+            default => false,
+        };
     }
 }

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -70,4 +70,19 @@ class Workspace extends Model
     {
         return $this->hasMany(User::class);
     }
+
+    public function ugcTasks(): HasMany
+    {
+        return $this->hasMany(UgcTask::class);
+    }
+
+    public function ugcApplications(): HasMany
+    {
+        return $this->hasMany(UgcApplication::class);
+    }
+
+    public function ugcSubmissions(): HasMany
+    {
+        return $this->hasMany(UgcSubmission::class);
+    }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Filament\AdminPanelProvider;
+use App\Filament\BusinessPanelProvider;
 use App\Http\Middleware\EnsureUserIsAdmin;
 use App\Http\Middleware\WorkspaceResolve;
 use Illuminate\Auth\Middleware\Authenticate;
@@ -26,6 +27,7 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withProviders([
         AdminPanelProvider::class,
+        BusinessPanelProvider::class,
         \App\Providers\AuthDebugServiceProvider::class,
     ])
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/database/migrations/2025_09_06_120000_add_business_profile_fields_to_accounts_table.php
+++ b/database/migrations/2025_09_06_120000_add_business_profile_fields_to_accounts_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('accounts', function (Blueprint $table): void {
+            $table->string('slug')->after('name');
+            $table->string('website_url')->nullable()->after('slug');
+            $table->string('support_email')->nullable()->after('website_url');
+            $table->string('support_phone')->nullable()->after('support_email');
+            $table->text('description')->nullable()->after('support_phone');
+            $table->string('logo_url')->nullable()->after('description');
+
+            $table->unique('slug');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('accounts', function (Blueprint $table): void {
+            $table->dropUnique(['slug']);
+            $table->dropColumn([
+                'slug',
+                'website_url',
+                'support_email',
+                'support_phone',
+                'description',
+                'logo_url',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2025_09_06_120100_create_ugc_tasks_table.php
+++ b/database/migrations/2025_09_06_120100_create_ugc_tasks_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ugc_tasks', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->string('slug');
+            $table->text('brief')->nullable();
+            $table->text('requirements')->nullable();
+            $table->string('reward')->nullable();
+            $table->string('status', 32)->default('draft');
+            $table->timestamp('published_at')->nullable();
+            $table->timestamp('deadline_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['workspace_id', 'slug']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ugc_tasks');
+    }
+};

--- a/database/migrations/2025_09_06_120200_create_ugc_applications_table.php
+++ b/database/migrations/2025_09_06_120200_create_ugc_applications_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ugc_applications', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('ugc_task_id')->constrained('ugc_tasks')->cascadeOnDelete();
+            $table->string('creator_name');
+            $table->string('creator_email');
+            $table->text('pitch')->nullable();
+            $table->string('status', 32)->default('pending');
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ugc_applications');
+    }
+};

--- a/database/migrations/2025_09_06_120300_create_ugc_submissions_table.php
+++ b/database/migrations/2025_09_06_120300_create_ugc_submissions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ugc_submissions', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('ugc_task_id')->constrained('ugc_tasks')->cascadeOnDelete();
+            $table->foreignId('ugc_application_id')->nullable()->constrained('ugc_applications')->nullOnDelete();
+            $table->string('content_url');
+            $table->text('notes')->nullable();
+            $table->string('status', 32)->default('submitted');
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ugc_submissions');
+    }
+};


### PR DESCRIPTION
## Summary
- add a dedicated business Filament panel and restrict panel access based on user role
- expose account profile editing for business users via a scoped resource
- introduce UGC task, application, and submission models, migrations, and Filament resources for workspace-scoped management

## Testing
- php artisan test *(fails: Class "Illuminate\Foundation\Application" not found when bootstrapping Laravel because vendor dependencies are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6edc5328832b96aa2c63744ee338