### PR TITLE
Add Twitter account OAuth integration endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,8 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 VITE_APP_NAME="${APP_NAME}"
 
 CLOUD_APP_ORIGIN=
+
+TWITTER_CLIENT_ID=
+TWITTER_CLIENT_SECRET=
+TWITTER_REDIRECT_URI=http://localhost/api/v1/twitter/oauth/callback
+TWITTER_SCOPES="tweet.read users.read offline.access"

--- a/app/Filament/Resources/TwitterAccountResource.php
+++ b/app/Filament/Resources/TwitterAccountResource.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\TwitterAccountResource\Pages\ListTwitterAccounts;
+use App\Models\TwitterAccount;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class TwitterAccountResource extends Resource
+{
+    protected static ?string $model = TwitterAccount::class;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Integrations';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-m-hashtag';
+    protected static ?string $navigationLabel = 'Twitter Accounts';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('connected_at', 'desc')
+            ->columns([
+                Tables\Columns\TextColumn::make('username')
+                    ->label('Handle')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('name')
+                    ->label('Display Name')
+                    ->searchable(),
+                Tables\Columns\BadgeColumn::make('status')
+                    ->label('Status')
+                    ->colors([
+                        'success' => 'connected',
+                        'danger' => 'disconnected',
+                    ])
+                    ->formatStateUsing(static fn(string $state): string => ucfirst($state)),
+                Tables\Columns\TextColumn::make('connected_at')
+                    ->label('Connected At')
+                    ->dateTime(),
+                Tables\Columns\TextColumn::make('disconnected_at')
+                    ->label('Disconnected At')
+                    ->dateTime()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->actions([])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListTwitterAccounts::route('/twitter-accounts'),
+        ];
+    }
+}

--- a/app/Filament/Resources/TwitterAccountResource/Pages/ListTwitterAccounts.php
+++ b/app/Filament/Resources/TwitterAccountResource/Pages/ListTwitterAccounts.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\TwitterAccountResource\Pages;
+
+use App\Filament\Resources\TwitterAccountResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTwitterAccounts extends ListRecords
+{
+    protected static string $resource = TwitterAccountResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Controllers/Api/V1/TwitterAccountController.php
+++ b/app/Http/Controllers/Api/V1/TwitterAccountController.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\TwitterAccount;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpFoundation\Response;
+
+class TwitterAccountController extends Controller
+{
+    private const AUTHORIZE_URL = 'https://twitter.com/i/oauth2/authorize';
+    private const TOKEN_URL = 'https://api.twitter.com/2/oauth2/token';
+    private const USER_URL = 'https://api.twitter.com/2/users/me';
+
+    public function index(): Response
+    {
+        $accounts = TwitterAccount::query()->latest('connected_at')->get();
+
+        return response()->json([
+            'data' => $accounts->map(fn (TwitterAccount $account): array => $this->transform($account))->all(),
+        ]);
+    }
+
+    public function redirect(Request $request): Response
+    {
+        $config = $this->twitterConfig();
+
+        $state = (string) Str::uuid();
+        $codeVerifier = Str::random(96);
+        $codeChallenge = $this->codeChallenge($codeVerifier);
+
+        Cache::put(
+            $this->cacheKey($state),
+            [
+                'user_id' => $request->user()->id,
+                'workspace_id' => currentWorkspace()->id,
+                'code_verifier' => $codeVerifier,
+            ],
+            now()->addMinutes(10),
+        );
+
+        $query = http_build_query([
+            'response_type' => 'code',
+            'client_id' => $config['client_id'],
+            'redirect_uri' => $config['redirect_uri'],
+            'scope' => implode(' ', $config['scopes']),
+            'state' => $state,
+            'code_challenge' => $codeChallenge,
+            'code_challenge_method' => 'S256',
+        ], '', '&', PHP_QUERY_RFC3986);
+
+        return response()->json([
+            'data' => [
+                'authorization_url' => sprintf('%s?%s', self::AUTHORIZE_URL, $query),
+                'state' => $state,
+            ],
+        ]);
+    }
+
+    public function callback(Request $request): Response
+    {
+        $data = $request->validate([
+            'code' => ['required', 'string'],
+            'state' => ['required', 'string'],
+        ]);
+
+        $stateData = Cache::pull($this->cacheKey($data['state']));
+
+        if ($stateData === null) {
+            throw ValidationException::withMessages([
+                'state' => ['The provided state is invalid or has expired.'],
+            ]);
+        }
+
+        if ((int) $stateData['user_id'] !== $request->user()->id || (int) $stateData['workspace_id'] !== currentWorkspace()->id) {
+            throw ValidationException::withMessages([
+                'state' => ['The provided state does not match the current session.'],
+            ]);
+        }
+
+        $config = $this->twitterConfig();
+
+        $tokenResponse = Http::asForm()->post(self::TOKEN_URL, [
+            'client_id' => $config['client_id'],
+            'client_secret' => $config['client_secret'],
+            'code' => $data['code'],
+            'grant_type' => 'authorization_code',
+            'redirect_uri' => $config['redirect_uri'],
+            'code_verifier' => $stateData['code_verifier'],
+        ]);
+
+        if ($tokenResponse->failed()) {
+            return response()->json([
+                'errors' => [[
+                    'status' => '400',
+                    'title' => 'Unable to exchange authorization code for access token.',
+                    'detail' => $tokenResponse->json('error_description') ?? $tokenResponse->body(),
+                ]],
+            ], 400);
+        }
+
+        $tokenData = $tokenResponse->json();
+
+        $userResponse = Http::withToken($tokenData['access_token'])
+            ->get(self::USER_URL, [
+                'user.fields' => 'name,username,profile_image_url',
+            ]);
+
+        if ($userResponse->failed()) {
+            return response()->json([
+                'errors' => [[
+                    'status' => '400',
+                    'title' => 'Unable to retrieve Twitter account information.',
+                    'detail' => $userResponse->json('error') ?? $userResponse->body(),
+                ]],
+            ], 400);
+        }
+
+        $userData = $userResponse->json('data', []);
+
+        $twitterId = Arr::get($userData, 'id');
+
+        if ($twitterId === null) {
+            return response()->json([
+                'errors' => [[
+                    'status' => '400',
+                    'title' => 'Twitter did not return an account identifier.',
+                ]],
+            ], 400);
+        }
+
+        $account = TwitterAccount::updateOrCreate(
+            [
+                'workspace_id' => currentWorkspace()->id,
+                'twitter_id' => $twitterId,
+            ],
+            [
+                'user_id' => $request->user()->id,
+                'username' => Arr::get($userData, 'username'),
+                'name' => Arr::get($userData, 'name'),
+                'profile_image_url' => Arr::get($userData, 'profile_image_url'),
+                'access_token' => $tokenData['access_token'],
+                'refresh_token' => $tokenData['refresh_token'] ?? null,
+                'token_expires_at' => isset($tokenData['expires_in']) ? now()->addSeconds((int) $tokenData['expires_in']) : null,
+                'scopes' => isset($tokenData['scope']) ? explode(' ', (string) $tokenData['scope']) : $config['scopes'],
+                'connected_at' => now(),
+                'disconnected_at' => null,
+            ],
+        );
+
+        return response()->json([
+            'data' => $this->transform($account->fresh()),
+        ]);
+    }
+
+    public function refresh(Request $request): Response
+    {
+        $data = $request->validate([
+            'twitter_account_id' => [
+                'required',
+                'integer',
+                Rule::exists('twitter_accounts', 'id')->where(fn ($query) => $query->where('workspace_id', currentWorkspace()->id)),
+            ],
+        ]);
+
+        /** @var TwitterAccount $account */
+        $account = TwitterAccount::query()->findOrFail($data['twitter_account_id']);
+
+        if (null === $account->refresh_token) {
+            return response()->json([
+                'errors' => [[
+                    'status' => '400',
+                    'title' => 'This Twitter account does not have a refresh token.',
+                ]],
+            ], 400);
+        }
+
+        $config = $this->twitterConfig();
+
+        $tokenResponse = Http::asForm()->post(self::TOKEN_URL, [
+            'client_id' => $config['client_id'],
+            'client_secret' => $config['client_secret'],
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $account->refresh_token,
+        ]);
+
+        if ($tokenResponse->failed()) {
+            return response()->json([
+                'errors' => [[
+                    'status' => '400',
+                    'title' => 'Unable to refresh access token.',
+                    'detail' => $tokenResponse->json('error_description') ?? $tokenResponse->body(),
+                ]],
+            ], 400);
+        }
+
+        $tokenData = $tokenResponse->json();
+
+        $account->forceFill([
+            'access_token' => $tokenData['access_token'],
+            'refresh_token' => $tokenData['refresh_token'] ?? $account->refresh_token,
+            'token_expires_at' => isset($tokenData['expires_in']) ? now()->addSeconds((int) $tokenData['expires_in']) : null,
+            'scopes' => isset($tokenData['scope']) ? explode(' ', (string) $tokenData['scope']) : $account->scopes,
+            'disconnected_at' => null,
+        ])->save();
+
+        return response()->json([
+            'data' => $this->transform($account->fresh()),
+        ]);
+    }
+
+    public function destroy(TwitterAccount $twitterAccount): Response
+    {
+        $twitterAccount->forceFill([
+            'access_token' => null,
+            'refresh_token' => null,
+            'token_expires_at' => null,
+            'disconnected_at' => now(),
+        ])->save();
+
+        return response()->json([
+            'data' => $this->transform($twitterAccount->fresh()),
+        ]);
+    }
+
+    private function twitterConfig(): array
+    {
+        $config = Config::get('services.twitter');
+
+        if (! is_array($config)) {
+            $config = [];
+        }
+
+        $required = ['client_id', 'client_secret', 'redirect_uri'];
+
+        foreach ($required as $key) {
+            if (empty($config[$key])) {
+                throw ValidationException::withMessages([
+                    'twitter' => [sprintf('Twitter configuration is missing the %s value.', $key)],
+                ]);
+            }
+        }
+
+        $config['scopes'] = array_values(array_filter($config['scopes'] ?? []));
+
+        return $config;
+    }
+
+    private function codeChallenge(string $verifier): string
+    {
+        return rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+    }
+
+    private function cacheKey(string $state): string
+    {
+        return sprintf('twitter-oauth:%s', $state);
+    }
+
+    private function transform(TwitterAccount $account): array
+    {
+        return [
+            'id' => $account->id,
+            'workspace_id' => $account->workspace_id,
+            'user_id' => $account->user_id,
+            'twitter_id' => $account->twitter_id,
+            'username' => $account->username,
+            'name' => $account->name,
+            'profile_image_url' => $account->profile_image_url,
+            'scopes' => $account->scopes,
+            'token_expires_at' => $account->token_expires_at?->toIso8601String(),
+            'connected_at' => $account->connected_at?->toIso8601String(),
+            'disconnected_at' => $account->disconnected_at?->toIso8601String(),
+            'status' => $account->status,
+            'is_connected' => $account->is_connected,
+        ];
+    }
+}

--- a/app/Models/TwitterAccount.php
+++ b/app/Models/TwitterAccount.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\ScopedToWorkspace;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TwitterAccount extends Model
+{
+    use HasFactory, ScopedToWorkspace;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'scopes' => 'array',
+        'token_expires_at' => 'datetime',
+        'connected_at' => 'datetime',
+        'disconnected_at' => 'datetime',
+    ];
+
+    protected $hidden = [
+        'access_token_encrypted',
+        'refresh_token_encrypted',
+    ];
+
+    protected $appends = [
+        'status',
+        'is_connected',
+    ];
+
+    public function workspace(): BelongsTo
+    {
+        return $this->belongsTo(Workspace::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    protected function accessToken(): Attribute
+    {
+        return Attribute::make(
+            get: fn(?string $value, array $attributes): ?string => isset($attributes['access_token_encrypted'])
+                ? decrypt($attributes['access_token_encrypted'])
+                : null,
+            set: fn(?string $value): array => [
+                'access_token_encrypted' => $value === null ? null : encrypt($value),
+            ],
+        );
+    }
+
+    protected function refreshToken(): Attribute
+    {
+        return Attribute::make(
+            get: fn(?string $value, array $attributes): ?string => isset($attributes['refresh_token_encrypted'])
+                ? decrypt($attributes['refresh_token_encrypted'])
+                : null,
+            set: fn(?string $value): array => [
+                'refresh_token_encrypted' => $value === null ? null : encrypt($value),
+            ],
+        );
+    }
+
+    public function getIsConnectedAttribute(): bool
+    {
+        return $this->disconnected_at === null;
+    }
+
+    public function getStatusAttribute(): string
+    {
+        return $this->is_connected ? 'connected' : 'disconnected';
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,6 +10,7 @@ use Filament\Models\Contracts\FilamentUser;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -65,6 +66,11 @@ class User extends Authenticatable implements FilamentUser
     public function account(): BelongsTo
     {
         return $this->belongsTo(Account::class);
+    }
+
+    public function twitterAccounts(): HasMany
+    {
+        return $this->hasMany(TwitterAccount::class);
     }
     public function canAccessPanel(Panel $panel): bool
     {

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -70,4 +70,9 @@ class Workspace extends Model
     {
         return $this->hasMany(User::class);
     }
+
+    public function twitterAccounts(): HasMany
+    {
+        return $this->hasMany(TwitterAccount::class);
+    }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,11 @@ return [
         ],
     ],
 
+    'twitter' => [
+        'client_id' => env('TWITTER_CLIENT_ID'),
+        'client_secret' => env('TWITTER_CLIENT_SECRET'),
+        'redirect_uri' => env('TWITTER_REDIRECT_URI'),
+        'scopes' => explode(' ', env('TWITTER_SCOPES', 'tweet.read users.read offline.access')),
+    ],
+
 ];

--- a/database/migrations/2025_09_06_100100_create_twitter_accounts_table.php
+++ b/database/migrations/2025_09_06_100100_create_twitter_accounts_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('twitter_accounts', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('workspace_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('twitter_id');
+            $table->string('username');
+            $table->string('name')->nullable();
+            $table->string('profile_image_url')->nullable();
+            $table->json('scopes')->nullable();
+            $table->text('access_token_encrypted');
+            $table->text('refresh_token_encrypted')->nullable();
+            $table->timestamp('token_expires_at')->nullable();
+            $table->timestamp('connected_at');
+            $table->timestamp('disconnected_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['workspace_id', 'twitter_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('twitter_accounts');
+    }
+};

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\V1\EventController;
 use App\Http\Controllers\Api\V1\SmtpSettingsController;
 use App\Http\Controllers\Api\V1\StatsController;
 use App\Http\Controllers\Api\V1\TemplateController;
+use App\Http\Controllers\Api\V1\TwitterAccountController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/auth/token', AuthTokenController::class)->middleware('workspace');
@@ -32,6 +33,12 @@ Route::middleware(['auth:sanctum', 'workspace'])->group(function (): void {
     Route::apiResource('templates', TemplateController::class);
     Route::post('/templates/{template}/preview', [TemplateController::class, 'preview']);
     Route::post('/templates/{template}/test', [TemplateController::class, 'test']);
+
+    Route::get('/twitter/accounts', [TwitterAccountController::class, 'index']);
+    Route::post('/twitter/oauth/redirect', [TwitterAccountController::class, 'redirect']);
+    Route::post('/twitter/oauth/callback', [TwitterAccountController::class, 'callback']);
+    Route::post('/twitter/oauth/refresh', [TwitterAccountController::class, 'refresh']);
+    Route::delete('/twitter/accounts/{twitterAccount}', [TwitterAccountController::class, 'destroy']);
 
     Route::middleware('admin')->get('/admin/stats', StatsController::class);
 });


### PR DESCRIPTION
## Summary
- add a migration and model for storing encrypted Twitter account credentials scoped to workspaces and users
- implement OAuth endpoints, routes, and configuration to connect, refresh, and disconnect Twitter accounts
- expose Twitter account connection status in the API and Filament via a dedicated resource

## Testing
- composer test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f5c648dc48832ba56132567b7eb8be