### PR TITLE
Implement Twitter follower polling and DM automation

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console;
 
+use App\Jobs\Twitter\DispatchFollowerPolling;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -11,7 +12,22 @@ class Kernel extends ConsoleKernel
 {
     protected function schedule(Schedule $schedule): void
     {
-        //
+        $connection = config('twitter.queues.connection', 'redis');
+        $queue = config('twitter.queues.poll_queue', 'twitter-polling');
+
+        foreach (config('twitter.polling.plans', []) as $plan => $interval) {
+            $interval = (int) $interval;
+            if ($interval <= 0) {
+                continue;
+            }
+
+            $schedule->job(new DispatchFollowerPolling($plan))
+                ->cron(sprintf('*/%d * * * *', $interval))
+                ->onConnection($connection)
+                ->onQueue($queue)
+                ->withoutOverlapping()
+                ->name(sprintf('twitter-followers-polling-%s', strtolower($plan)));
+        }
     }
 
     protected function commands(): void

--- a/app/Jobs/Twitter/DispatchFollowerPolling.php
+++ b/app/Jobs/Twitter/DispatchFollowerPolling.php
@@ -16,10 +16,6 @@ class DispatchFollowerPolling implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public string $connection;
-
-    public string $queue;
-
     public function __construct(public string $planName)
     {
         $this->connection = config('twitter.queues.connection', 'redis');

--- a/app/Jobs/Twitter/DispatchFollowerPolling.php
+++ b/app/Jobs/Twitter/DispatchFollowerPolling.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Twitter;
+
+use App\Models\TwitterAccount;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class DispatchFollowerPolling implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public string $connection;
+
+    public string $queue;
+
+    public function __construct(public string $planName)
+    {
+        $this->connection = config('twitter.queues.connection', 'redis');
+        $this->queue = config('twitter.queues.poll_queue', 'twitter-polling');
+        $this->onConnection($this->connection);
+        $this->onQueue($this->queue);
+    }
+
+    public function handle(): void
+    {
+        $accounts = TwitterAccount::query()
+            ->whereNull('disconnected_at')
+            ->whereHas('workspace.account.plan', function ($query): void {
+                $query->where('name', $this->planName);
+            })
+            ->get();
+
+        if ($accounts->isEmpty()) {
+            return;
+        }
+
+        foreach ($accounts as $account) {
+            if (empty($account->access_token)) {
+                Log::warning('Skipping Twitter follower polling for account without access token', [
+                    'twitter_account_id' => $account->id,
+                ]);
+                continue;
+            }
+
+            PollFollowers::dispatch($account)->onConnection($this->connection)->onQueue($this->queue);
+        }
+    }
+}

--- a/app/Jobs/Twitter/PollFollowers.php
+++ b/app/Jobs/Twitter/PollFollowers.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Twitter;
+
+use App\Models\TwitterAccount;
+use App\Models\TwitterFollower;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class PollFollowers implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public string $connection;
+
+    public string $queue;
+
+    public function __construct(public TwitterAccount $twitterAccount)
+    {
+        $this->connection = config('twitter.queues.connection', 'redis');
+        $this->queue = config('twitter.queues.poll_queue', 'twitter-polling');
+        $this->onConnection($this->connection);
+        $this->onQueue($this->queue);
+    }
+
+    public function handle(): void
+    {
+        $account = $this->twitterAccount->fresh();
+        if ($account === null || $account->disconnected_at !== null) {
+            return;
+        }
+
+        $token = $account->access_token;
+        if ($token === null) {
+            Log::warning('Twitter polling skipped due to missing access token', [
+                'twitter_account_id' => $account->id,
+            ]);
+            return;
+        }
+
+        $url = sprintf('%s/2/users/%s/followers', config('twitter.base_url'), $account->twitter_id);
+        $response = Http::withToken($token)
+            ->acceptJson()
+            ->get($url, [
+                'max_results' => config('twitter.polling.page_size'),
+                'user.fields' => 'id,name,username',
+            ]);
+
+        if ($response->failed()) {
+            Log::error('Twitter followers API request failed', [
+                'twitter_account_id' => $account->id,
+                'status' => $response->status(),
+                'body' => $response->json(),
+            ]);
+            return;
+        }
+
+        $followers = $response->json('data', []);
+        if (! is_array($followers)) {
+            Log::warning('Twitter followers API returned unexpected payload', [
+                'twitter_account_id' => $account->id,
+            ]);
+            return;
+        }
+
+        $welcomeMessage = config('twitter.dm.welcome_message');
+        foreach ($followers as $follower) {
+            $followerId = $follower['id'] ?? null;
+            if ($followerId === null) {
+                continue;
+            }
+
+            $record = TwitterFollower::query()->firstOrCreate(
+                [
+                    'twitter_account_id' => $account->id,
+                    'follower_id' => $followerId,
+                ],
+                [
+                    'username' => $follower['username'] ?? null,
+                    'name' => $follower['name'] ?? null,
+                    'seen_at' => Carbon::now(),
+                ],
+            );
+
+            if (! $record->wasRecentlyCreated) {
+                continue;
+            }
+
+            SendDirectMessage::dispatch(
+                $account,
+                $followerId,
+                $welcomeMessage,
+            )->onConnection(config('twitter.queues.connection', 'redis'))
+                ->onQueue(config('twitter.queues.dm_queue', 'twitter-dm'));
+        }
+
+        $account->forceFill([
+            'last_polled_at' => Carbon::now(),
+        ])->save();
+    }
+}

--- a/app/Jobs/Twitter/PollFollowers.php
+++ b/app/Jobs/Twitter/PollFollowers.php
@@ -43,60 +43,76 @@ class PollFollowers implements ShouldQueue
         }
 
         $url = sprintf('%s/2/users/%s/followers', config('twitter.base_url'), $account->twitter_id);
-        $response = Http::withToken($token)
-            ->acceptJson()
-            ->get($url, [
+        $paginationToken = null;
+        $welcomeMessage = config('twitter.dm.welcome_message');
+        $queueConnection = config('twitter.queues.connection', 'redis');
+        $dmQueue = config('twitter.queues.dm_queue', 'twitter-dm');
+
+        do {
+            $query = [
                 'max_results' => config('twitter.polling.page_size'),
                 'user.fields' => 'id,name,username',
-            ]);
+            ];
 
-        if ($response->failed()) {
-            Log::error('Twitter followers API request failed', [
-                'twitter_account_id' => $account->id,
-                'status' => $response->status(),
-                'body' => $response->json(),
-            ]);
-            return;
-        }
-
-        $followers = $response->json('data', []);
-        if (! is_array($followers)) {
-            Log::warning('Twitter followers API returned unexpected payload', [
-                'twitter_account_id' => $account->id,
-            ]);
-            return;
-        }
-
-        $welcomeMessage = config('twitter.dm.welcome_message');
-        foreach ($followers as $follower) {
-            $followerId = $follower['id'] ?? null;
-            if ($followerId === null) {
-                continue;
+            if ($paginationToken !== null) {
+                $query['pagination_token'] = $paginationToken;
             }
 
-            $record = TwitterFollower::query()->firstOrCreate(
-                [
+            $response = Http::withToken($token)
+                ->acceptJson()
+                ->get($url, $query);
+
+            if ($response->failed()) {
+                Log::error('Twitter followers API request failed', [
                     'twitter_account_id' => $account->id,
-                    'follower_id' => $followerId,
-                ],
-                [
-                    'username' => $follower['username'] ?? null,
-                    'name' => $follower['name'] ?? null,
-                    'seen_at' => Carbon::now(),
-                ],
-            );
+                    'status' => $response->status(),
+                    'body' => $response->json(),
+                ]);
 
-            if (! $record->wasRecentlyCreated) {
-                continue;
+                return;
             }
 
-            SendDirectMessage::dispatch(
-                $account,
-                $followerId,
-                $welcomeMessage,
-            )->onConnection(config('twitter.queues.connection', 'redis'))
-                ->onQueue(config('twitter.queues.dm_queue', 'twitter-dm'));
-        }
+            $followers = $response->json('data', []);
+            if (! is_array($followers)) {
+                Log::warning('Twitter followers API returned unexpected payload', [
+                    'twitter_account_id' => $account->id,
+                ]);
+
+                return;
+            }
+
+            foreach ($followers as $follower) {
+                $followerId = $follower['id'] ?? null;
+                if ($followerId === null) {
+                    continue;
+                }
+
+                $record = TwitterFollower::query()->firstOrCreate(
+                    [
+                        'twitter_account_id' => $account->id,
+                        'follower_id' => $followerId,
+                    ],
+                    [
+                        'username' => $follower['username'] ?? null,
+                        'name' => $follower['name'] ?? null,
+                        'seen_at' => Carbon::now(),
+                    ],
+                );
+
+                if (! $record->wasRecentlyCreated) {
+                    continue;
+                }
+
+                SendDirectMessage::dispatch(
+                    $account,
+                    $followerId,
+                    $welcomeMessage,
+                )->onConnection($queueConnection)
+                    ->onQueue($dmQueue);
+            }
+
+            $paginationToken = $response->json('meta.next_token');
+        } while ($paginationToken !== null);
 
         $account->forceFill([
             'last_polled_at' => Carbon::now(),

--- a/app/Jobs/Twitter/PollFollowers.php
+++ b/app/Jobs/Twitter/PollFollowers.php
@@ -19,10 +19,6 @@ class PollFollowers implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public string $connection;
-
-    public string $queue;
-
     public function __construct(public TwitterAccount $twitterAccount)
     {
         $this->connection = config('twitter.queues.connection', 'redis');

--- a/app/Jobs/Twitter/SendDirectMessage.php
+++ b/app/Jobs/Twitter/SendDirectMessage.php
@@ -18,10 +18,6 @@ class SendDirectMessage implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public string $connection;
-
-    public string $queue;
-
     public function __construct(
         public TwitterAccount $twitterAccount,
         public string $participantId,

--- a/app/Jobs/Twitter/SendDirectMessage.php
+++ b/app/Jobs/Twitter/SendDirectMessage.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Twitter;
+
+use App\Models\TwitterAccount;
+use App\Services\Twitter\DirectMessageSender;
+use App\Services\Twitter\Exceptions\RateLimitException;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class SendDirectMessage implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public string $connection;
+
+    public string $queue;
+
+    public function __construct(
+        public TwitterAccount $twitterAccount,
+        public string $participantId,
+        public string $message,
+    ) {
+        $this->connection = config('twitter.queues.connection', 'redis');
+        $this->queue = config('twitter.queues.dm_queue', 'twitter-dm');
+        $this->onConnection($this->connection);
+        $this->onQueue($this->queue);
+    }
+
+    public function handle(DirectMessageSender $sender): void
+    {
+        $account = $this->twitterAccount->fresh();
+        if ($account === null || $account->disconnected_at !== null) {
+            return;
+        }
+
+        try {
+            $sender->send($account, $this->participantId, $this->message);
+        } catch (RateLimitException $exception) {
+            $delay = max(1, $exception->retryAfter ?? config('twitter.dm.backoff.default_retry_after'));
+            $this->release($delay);
+        } catch (\Throwable $exception) {
+            Log::error('Failed to send Twitter direct message', [
+                'twitter_account_id' => $account->id,
+                'participant_id' => $this->participantId,
+                'error' => $exception->getMessage(),
+            ]);
+            throw $exception;
+        }
+    }
+}

--- a/app/Models/TwitterAccount.php
+++ b/app/Models/TwitterAccount.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class TwitterAccount extends Model
 {
@@ -21,6 +22,7 @@ class TwitterAccount extends Model
         'token_expires_at' => 'datetime',
         'connected_at' => 'datetime',
         'disconnected_at' => 'datetime',
+        'last_polled_at' => 'datetime',
     ];
 
     protected $hidden = [
@@ -41,6 +43,11 @@ class TwitterAccount extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function followers(): HasMany
+    {
+        return $this->hasMany(TwitterFollower::class);
     }
 
     protected function accessToken(): Attribute

--- a/app/Models/TwitterFollower.php
+++ b/app/Models/TwitterFollower.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TwitterFollower extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'seen_at' => 'datetime',
+    ];
+
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(TwitterAccount::class, 'twitter_account_id');
+    }
+}

--- a/app/Services/RateLimiter/TokenBucketLimiter.php
+++ b/app/Services/RateLimiter/TokenBucketLimiter.php
@@ -20,7 +20,11 @@ class TokenBucketLimiter
 
     public function consume(int $workspaceId, int $perMinute, int $tokens = 1): bool
     {
-        $key = "rate:" . $workspaceId;
+        return $this->consumeKey("rate:" . $workspaceId, $perMinute, $tokens);
+    }
+
+    public function consumeKey(string $key, int $perMinute, int $tokens = 1): bool
+    {
         $now = microtime(true);
 
         try {

--- a/app/Services/Twitter/DirectMessageSender.php
+++ b/app/Services/Twitter/DirectMessageSender.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Twitter;
+
+use App\Models\TwitterAccount;
+use App\Services\RateLimiter\TokenBucketLimiter;
+use App\Services\Twitter\Exceptions\DirectMessageException;
+use App\Services\Twitter\Exceptions\RateLimitException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class DirectMessageSender
+{
+    public function __construct(private TokenBucketLimiter $limiter)
+    {
+    }
+
+    public function send(TwitterAccount $account, string $participantId, string $message): void
+    {
+        $this->enforceRateLimits($account);
+
+        $token = $account->access_token;
+        if ($token === null) {
+            throw new DirectMessageException('Twitter access token is missing for account '.$account->id);
+        }
+
+        $attempts = max(1, (int) config('twitter.dm.backoff.attempts', 3));
+        $delay = max(1, (int) config('twitter.dm.backoff.initial_seconds', 2));
+        $endpoint = sprintf('%s/2/dm_conversations/with/%s/messages', config('twitter.base_url'), $participantId);
+
+        $attempt = 0;
+        $lastException = null;
+
+        while ($attempt < $attempts) {
+            $attempt++;
+
+            try {
+                $response = Http::withToken($token)
+                    ->acceptJson()
+                    ->post($endpoint, [
+                        'text' => $message,
+                    ]);
+
+                if ($response->successful()) {
+                    Log::info('Twitter direct message sent', [
+                        'twitter_account_id' => $account->id,
+                        'participant_id' => $participantId,
+                    ]);
+                    return;
+                }
+
+                if ($response->status() === 429) {
+                    $retryAfter = $this->parseRetryAfter($response->header('retry-after'));
+                    throw new RateLimitException('Twitter API rate limit exceeded.', $retryAfter);
+                }
+
+                $response->throw();
+            } catch (RateLimitException $exception) {
+                Log::warning('Twitter direct message hit API rate limit', [
+                    'twitter_account_id' => $account->id,
+                    'participant_id' => $participantId,
+                    'retry_after' => $exception->retryAfter,
+                ]);
+                throw $exception;
+            } catch (RequestException $exception) {
+                $lastException = $exception;
+            } catch (Throwable $exception) {
+                $lastException = $exception;
+            }
+
+            if ($attempt >= $attempts) {
+                break;
+            }
+
+            sleep($delay);
+            $delay *= 2;
+        }
+
+        $errorMessage = $lastException instanceof Throwable ? $lastException->getMessage() : 'Unknown error';
+        throw new DirectMessageException('Unable to send Twitter direct message: '.$errorMessage, previous: $lastException);
+    }
+
+    private function enforceRateLimits(TwitterAccount $account): void
+    {
+        $limits = config('twitter.dm.rate_limits');
+
+        $perUser = $limits['per_user'] ?? null;
+        if ($perUser !== null && ($perUser['per_minute'] ?? 0) > 0) {
+            $key = ($perUser['key_prefix'] ?? 'twitter:dm:user:').$account->id;
+            if (! $this->limiter->consumeKey($key, (int) $perUser['per_minute'])) {
+                $retryAfter = (int) config('twitter.dm.backoff.default_retry_after', 60);
+                throw new RateLimitException('Per-user DM rate limit reached.', $retryAfter);
+            }
+        }
+
+        $perApp = $limits['per_app'] ?? null;
+        if ($perApp !== null && ($perApp['per_minute'] ?? 0) > 0) {
+            $key = $perApp['key'] ?? 'twitter:dm:app';
+            if (! $this->limiter->consumeKey($key, (int) $perApp['per_minute'])) {
+                $retryAfter = (int) config('twitter.dm.backoff.default_retry_after', 60);
+                throw new RateLimitException('App-wide DM rate limit reached.', $retryAfter);
+            }
+        }
+    }
+
+    private function parseRetryAfter(?string $header): int
+    {
+        if ($header === null) {
+            return (int) config('twitter.dm.backoff.default_retry_after', 60);
+        }
+
+        if (is_numeric($header)) {
+            return max(1, (int) $header);
+        }
+
+        try {
+            $retry = Carbon::now()->diffInSeconds(Carbon::parse($header));
+            return max(1, $retry);
+        } catch (Throwable) {
+            return (int) config('twitter.dm.backoff.default_retry_after', 60);
+        }
+    }
+}

--- a/app/Services/Twitter/Exceptions/DirectMessageException.php
+++ b/app/Services/Twitter/Exceptions/DirectMessageException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Twitter\Exceptions;
+
+use RuntimeException;
+
+class DirectMessageException extends RuntimeException
+{
+}

--- a/app/Services/Twitter/Exceptions/RateLimitException.php
+++ b/app/Services/Twitter/Exceptions/RateLimitException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Twitter\Exceptions;
+
+class RateLimitException extends DirectMessageException
+{
+    public function __construct(string $message, public ?int $retryAfter = null)
+    {
+        parent::__construct($message);
+    }
+}

--- a/config/twitter.php
+++ b/config/twitter.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    'base_url' => rtrim(env('TWITTER_API_BASE_URL', 'https://api.x.com'), '/'),
+
+    'polling' => [
+        'page_size' => (int) env('TWITTER_FOLLOWER_PAGE_SIZE', 100),
+        'plans' => [
+            'Free' => (int) env('TWITTER_POLL_INTERVAL_FREE', 30),
+            'Pro' => (int) env('TWITTER_POLL_INTERVAL_PRO', 10),
+            'Enterprise' => (int) env('TWITTER_POLL_INTERVAL_ENTERPRISE', 5),
+        ],
+    ],
+
+    'queues' => [
+        'connection' => env('TWITTER_QUEUE_CONNECTION', 'redis'),
+        'poll_queue' => env('TWITTER_POLL_QUEUE', 'twitter-polling'),
+        'dm_queue' => env('TWITTER_DM_QUEUE', 'twitter-dm'),
+    ],
+
+    'dm' => [
+        'welcome_message' => env('TWITTER_WELCOME_MESSAGE', 'Thanks for following us on X!'),
+        'backoff' => [
+            'attempts' => (int) env('TWITTER_DM_ATTEMPTS', 3),
+            'initial_seconds' => (int) env('TWITTER_DM_INITIAL_BACKOFF', 2),
+            'default_retry_after' => (int) env('TWITTER_DM_DEFAULT_RETRY_AFTER', 60),
+        ],
+        'rate_limits' => [
+            'per_user' => [
+                'key_prefix' => 'twitter:dm:user:',
+                'per_minute' => (int) env('TWITTER_DM_PER_USER_PER_MINUTE', 15),
+            ],
+            'per_app' => [
+                'key' => 'twitter:dm:app',
+                'per_minute' => (int) env('TWITTER_DM_PER_APP_PER_MINUTE', 300),
+            ],
+        ],
+    ],
+];

--- a/database/migrations/2025_09_07_000000_create_twitter_followers_table.php
+++ b/database/migrations/2025_09_07_000000_create_twitter_followers_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('twitter_followers', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('twitter_account_id')->constrained()->cascadeOnDelete();
+            $table->string('follower_id');
+            $table->string('username')->nullable();
+            $table->string('name')->nullable();
+            $table->timestamp('seen_at')->useCurrent();
+            $table->timestamps();
+
+            $table->unique(['twitter_account_id', 'follower_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('twitter_followers');
+    }
+};

--- a/database/migrations/2025_09_07_000100_add_last_polled_at_to_twitter_accounts_table.php
+++ b/database/migrations/2025_09_07_000100_add_last_polled_at_to_twitter_accounts_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('twitter_accounts', function (Blueprint $table): void {
+            $table->timestamp('last_polled_at')->nullable()->after('disconnected_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('twitter_accounts', function (Blueprint $table): void {
+            $table->dropColumn('last_polled_at');
+        });
+    }
+};

--- a/tests/Feature/Twitter/DispatchFollowerPollingTest.php
+++ b/tests/Feature/Twitter/DispatchFollowerPollingTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\Twitter\DispatchFollowerPolling;
+use App\Jobs\Twitter\PollFollowers;
+use App\Models\Plan;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+it('dispatches follower polling jobs for accounts on the matching plan with access tokens', function () {
+    Queue::fake();
+
+    $plan = Plan::factory()->create(['name' => 'Pro']);
+    $matchingAccount = createTwitterAccountForPlan($plan);
+    $withoutToken = createTwitterAccountForPlan($plan, [
+        'access_token' => '',
+    ]);
+    $otherPlanAccount = createTwitterAccountForPlanName('Free');
+
+    (new DispatchFollowerPolling('Pro'))->handle();
+
+    Queue::assertPushedOn(config('twitter.queues.poll_queue'), PollFollowers::class, function ($job) use ($matchingAccount) {
+        return $job->twitterAccount->is($matchingAccount)
+            && $job->connection === config('twitter.queues.connection')
+            && $job->queue === config('twitter.queues.poll_queue');
+    });
+
+    Queue::assertNotPushed(PollFollowers::class, function ($job) use ($withoutToken) {
+        return $job->twitterAccount->is($withoutToken);
+    });
+
+    Queue::assertNotPushed(PollFollowers::class, function ($job) use ($otherPlanAccount) {
+        return $job->twitterAccount->is($otherPlanAccount);
+    });
+
+    Queue::assertPushed(PollFollowers::class, 1);
+});

--- a/tests/Feature/Twitter/PollFollowersTest.php
+++ b/tests/Feature/Twitter/PollFollowersTest.php
@@ -93,3 +93,60 @@ it('does not dispatch direct messages for followers already seen', function () {
 
     Carbon::setTestNow();
 });
+
+it('paginates through all follower pages to welcome each new follower', function () {
+    Queue::fake();
+    config(['twitter.dm.welcome_message' => 'Welcome aboard!']);
+
+    $account = createTwitterAccountForPlanName('Pro');
+
+    Http::fake([
+        sprintf('%s/2/users/%s/followers*', config('twitter.base_url'), $account->twitter_id) => Http::sequence()
+            ->push([
+                'data' => [
+                    [
+                        'id' => '333',
+                        'username' => 'first-page-user',
+                        'name' => 'First Page User',
+                    ],
+                ],
+                'meta' => [
+                    'next_token' => 'NEXT_TOKEN',
+                ],
+            ], 200)
+            ->push([
+                'data' => [
+                    [
+                        'id' => '444',
+                        'username' => 'second-page-user',
+                        'name' => 'Second Page User',
+                    ],
+                ],
+            ], 200),
+    ]);
+
+    (new PollFollowers($account))->handle();
+
+    $followerIds = TwitterFollower::query()
+        ->where('twitter_account_id', $account->id)
+        ->pluck('follower_id')
+        ->all();
+
+    expect($followerIds)->toBe(['333', '444']);
+
+    $dmQueue = config('twitter.queues.dm_queue');
+
+    Queue::assertPushed(SendDirectMessage::class, 2);
+
+    Queue::assertPushedOn($dmQueue, SendDirectMessage::class, function (SendDirectMessage $job) use ($account) {
+        return $job->twitterAccount->is($account)
+            && $job->participantId === '333'
+            && $job->message === 'Welcome aboard!';
+    });
+
+    Queue::assertPushedOn($dmQueue, SendDirectMessage::class, function (SendDirectMessage $job) use ($account) {
+        return $job->twitterAccount->is($account)
+            && $job->participantId === '444'
+            && $job->message === 'Welcome aboard!';
+    });
+});

--- a/tests/Feature/Twitter/PollFollowersTest.php
+++ b/tests/Feature/Twitter/PollFollowersTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\Twitter\PollFollowers;
+use App\Jobs\Twitter\SendDirectMessage;
+use App\Models\TwitterFollower;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+it('persists new followers and dispatches direct message jobs', function () {
+    Queue::fake();
+    $now = Carbon::parse('2025-01-01 00:00:00');
+    Carbon::setTestNow($now);
+
+    config(['twitter.dm.welcome_message' => 'Hello follower!']);
+
+    $account = createTwitterAccountForPlanName('Pro');
+
+    Http::fake([
+        sprintf('%s/2/users/%s/followers*', config('twitter.base_url'), $account->twitter_id) => Http::response([
+            'data' => [
+                [
+                    'id' => '111',
+                    'username' => 'first-user',
+                    'name' => 'First User',
+                ],
+            ],
+        ], 200),
+    ]);
+
+    (new PollFollowers($account))->handle();
+
+    $follower = TwitterFollower::query()
+        ->where('twitter_account_id', $account->id)
+        ->first();
+
+    expect($follower)->not->toBeNull();
+    expect($follower->follower_id)->toBe('111');
+    expect($follower->username)->toBe('first-user');
+    expect($follower->name)->toBe('First User');
+    expect($follower->seen_at?->diffInSeconds($now))->toBeLessThan(1);
+
+    expect($account->fresh()->last_polled_at?->diffInSeconds($now))->toBeLessThan(1);
+
+    Queue::assertPushedOn(config('twitter.queues.dm_queue'), SendDirectMessage::class, function ($job) use ($account) {
+        return $job->twitterAccount->is($account)
+            && $job->participantId === '111'
+            && $job->message === 'Hello follower!';
+    });
+
+    Queue::assertPushed(SendDirectMessage::class, 1);
+
+    Carbon::setTestNow();
+});
+
+it('does not dispatch direct messages for followers already seen', function () {
+    Queue::fake();
+    $now = Carbon::parse('2025-01-01 00:00:00');
+    Carbon::setTestNow($now);
+
+    $account = createTwitterAccountForPlanName('Pro');
+
+    TwitterFollower::create([
+        'twitter_account_id' => $account->id,
+        'follower_id' => '222',
+        'username' => 'existing',
+        'name' => 'Existing User',
+        'seen_at' => now()->subDay(),
+    ]);
+
+    Http::fake([
+        sprintf('%s/2/users/%s/followers*', config('twitter.base_url'), $account->twitter_id) => Http::response([
+            'data' => [
+                [
+                    'id' => '222',
+                    'username' => 'existing',
+                    'name' => 'Existing User',
+                ],
+            ],
+        ], 200),
+    ]);
+
+    (new PollFollowers($account))->handle();
+
+    Queue::assertNotPushed(SendDirectMessage::class);
+    expect(TwitterFollower::query()->count())->toBe(1);
+    expect($account->fresh()->last_polled_at?->diffInSeconds($now))->toBeLessThan(1);
+
+    Carbon::setTestNow();
+});

--- a/tests/Feature/Twitter/SendDirectMessageJobTest.php
+++ b/tests/Feature/Twitter/SendDirectMessageJobTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\Twitter\SendDirectMessage;
+use App\Services\Twitter\DirectMessageSender;
+use App\Services\Twitter\Exceptions\RateLimitException;
+use Illuminate\Contracts\Queue\Job as QueueJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+uses(RefreshDatabase::class);
+
+afterEach(function (): void {
+    \Mockery::close();
+});
+
+it('delegates direct message sending to the twitter service when the account is active', function () {
+    $account = createTwitterAccountForPlanName('Pro');
+
+    $job = new SendDirectMessage($account, '789', 'Welcome!');
+
+    $sender = \Mockery::mock(DirectMessageSender::class);
+    $sender->shouldReceive('send')
+        ->once()
+        ->with(\Mockery::on(fn ($freshAccount) => $freshAccount->is($account)), '789', 'Welcome!');
+
+    $job->handle($sender);
+});
+
+it('releases the job with the provided retry delay when a rate limit is encountered', function () {
+    $account = createTwitterAccountForPlanName('Pro');
+
+    $job = new SendDirectMessage($account, '123', 'Hello');
+
+    $queueJob = \Mockery::mock(QueueJob::class);
+    $queueJob->shouldReceive('release')->once()->with(10);
+    $job->setJob($queueJob);
+
+    $sender = \Mockery::mock(DirectMessageSender::class);
+    $sender->shouldReceive('send')
+        ->once()
+        ->andThrow(new RateLimitException('Rate limit hit', 10));
+
+    $job->handle($sender);
+});
+
+it('does not attempt to send a direct message when the account is disconnected', function () {
+    $account = createTwitterAccountForPlanName('Pro', [
+        'disconnected_at' => now(),
+    ]);
+
+    $job = new SendDirectMessage($account, '456', 'Hello again');
+
+    $sender = \Mockery::mock(DirectMessageSender::class);
+    $sender->shouldReceive('send')->never();
+
+    $job->handle($sender);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,11 @@
 <?php
 
+use App\Models\Account;
+use App\Models\Plan;
+use App\Models\TwitterAccount;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Support\Str;
 use Predis\Client;
 
 /*
@@ -16,6 +22,9 @@ use Predis\Client;
 pest()->extend(Tests\TestCase::class)
  // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature');
+
+pest()->extend(Tests\TestCase::class)
+    ->in('Unit/Twitter');
 
 uses()->beforeEach(function (): void {
     (new Client())->flushdb();
@@ -46,6 +55,39 @@ expect()->extend('toBeOne', function () {
 | global functions to help you to reduce the number of lines of code in your test files.
 |
 */
+
+function createTwitterAccountForPlanName(string $planName, array $attributes = []): TwitterAccount
+{
+    $plan = Plan::factory()->create(['name' => $planName]);
+
+    return createTwitterAccountForPlan($plan, $attributes);
+}
+
+function createTwitterAccountForPlan(Plan $plan, array $attributes = []): TwitterAccount
+{
+    $account = Account::factory()->for($plan, 'plan')->create();
+    $workspace = Workspace::factory()->for($account, 'account')->create();
+    $user = User::factory()->for($workspace)->create([
+        'account_id' => $account->id,
+    ]);
+
+    $defaults = [
+        'workspace_id' => $workspace->id,
+        'user_id' => $user->id,
+        'twitter_id' => (string) Str::random(12),
+        'username' => Str::lower(Str::random(8)),
+        'name' => 'Test Twitter Account',
+        'profile_image_url' => null,
+        'scopes' => [],
+        'access_token' => 'token-'.Str::random(16),
+        'refresh_token' => null,
+        'token_expires_at' => now()->addHour(),
+        'connected_at' => now(),
+        'disconnected_at' => null,
+    ];
+
+    return TwitterAccount::create(array_merge($defaults, $attributes));
+}
 
 function something()
 {

--- a/tests/Unit/Twitter/DirectMessageSenderTest.php
+++ b/tests/Unit/Twitter/DirectMessageSenderTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\RateLimiter\TokenBucketLimiter;
+use App\Services\Twitter\DirectMessageSender;
+use App\Services\Twitter\Exceptions\DirectMessageException;
+use App\Services\Twitter\Exceptions\RateLimitException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    config([
+        'twitter.dm.rate_limits.per_user.key_prefix' => 'twitter:dm:user:',
+        'twitter.dm.rate_limits.per_user.per_minute' => 15,
+        'twitter.dm.rate_limits.per_app.key' => 'twitter:dm:app',
+        'twitter.dm.rate_limits.per_app.per_minute' => 300,
+        'twitter.dm.backoff.attempts' => 1,
+        'twitter.dm.backoff.initial_seconds' => 1,
+        'twitter.dm.backoff.default_retry_after' => 60,
+    ]);
+});
+
+afterEach(function (): void {
+    \Mockery::close();
+});
+
+it('sends a direct message when rate limits allow and the API succeeds', function () {
+    $account = createTwitterAccountForPlanName('Pro');
+
+    $limiter = \Mockery::mock(TokenBucketLimiter::class);
+    $limiter->shouldReceive('consumeKey')->once()->with('twitter:dm:user:'.$account->id, 15)->andReturnTrue();
+    $limiter->shouldReceive('consumeKey')->once()->with('twitter:dm:app', 300)->andReturnTrue();
+
+    Http::fake([
+        sprintf('%s/2/dm_conversations/with/%s/messages', config('twitter.base_url'), '111') => Http::response([], 200),
+    ]);
+
+    $sender = new DirectMessageSender($limiter);
+    $sender->send($account->fresh(), '111', 'Hello there');
+
+    Http::assertSent(function ($request) {
+        return $request->method() === 'POST'
+            && str_contains($request->url(), '/2/dm_conversations/with/111/messages')
+            && $request['text'] === 'Hello there';
+    });
+});
+
+it('throws a rate limit exception when the per-user limiter is exhausted', function () {
+    $account = createTwitterAccountForPlanName('Pro');
+
+    $limiter = \Mockery::mock(TokenBucketLimiter::class);
+    $limiter->shouldReceive('consumeKey')->once()->with('twitter:dm:user:'.$account->id, 15)->andReturnFalse();
+
+    $sender = new DirectMessageSender($limiter);
+
+    Http::fake();
+
+    expect(fn () => $sender->send($account->fresh(), '222', 'Hello'))
+        ->toThrow(RateLimitException::class);
+
+    Http::assertNothingSent();
+});
+
+it('throws a rate limit exception when the Twitter API responds with 429', function () {
+    $account = createTwitterAccountForPlanName('Pro');
+
+    $limiter = \Mockery::mock(TokenBucketLimiter::class);
+    $limiter->shouldReceive('consumeKey')->once()->with('twitter:dm:user:'.$account->id, 15)->andReturnTrue();
+    $limiter->shouldReceive('consumeKey')->once()->with('twitter:dm:app', 300)->andReturnTrue();
+
+    Http::fake([
+        sprintf('%s/2/dm_conversations/with/%s/messages', config('twitter.base_url'), '333') => Http::response([], 429, [
+            'retry-after' => '120',
+        ]),
+    ]);
+
+    $sender = new DirectMessageSender($limiter);
+
+    $exception = null;
+
+    try {
+        $sender->send($account->fresh(), '333', 'Hi');
+    } catch (RateLimitException $rateLimit) {
+        $exception = $rateLimit;
+    }
+
+    expect($exception)->not->toBeNull();
+    expect($exception->retryAfter)->toBe(120);
+});
+
+it('wraps failures from the Twitter API in a direct message exception', function () {
+    $account = createTwitterAccountForPlanName('Pro');
+
+    $limiter = \Mockery::mock(TokenBucketLimiter::class);
+    $limiter->shouldReceive('consumeKey')->once()->with('twitter:dm:user:'.$account->id, 15)->andReturnTrue();
+    $limiter->shouldReceive('consumeKey')->once()->with('twitter:dm:app', 300)->andReturnTrue();
+
+    Http::fake([
+        sprintf('%s/2/dm_conversations/with/%s/messages', config('twitter.base_url'), '444') => Http::response([], 500),
+    ]);
+
+    $sender = new DirectMessageSender($limiter);
+
+    expect(fn () => $sender->send($account->fresh(), '444', 'Oops'))
+        ->toThrow(DirectMessageException::class);
+});


### PR DESCRIPTION
## Summary
- add Twitter configuration, follower persistence, and scheduling hooks for plan-based polling
- implement jobs to poll followers, diff against stored follower IDs, and queue DM deliveries for new accounts
- build a Redis-backed DM sender with exponential backoff and per-user / app rate limiting

## Testing
- composer test *(fails: missing vendor/autoload.php in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f5cb280be4832b979af2e0aa5ca2c3